### PR TITLE
自动获取榜单。

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,9 @@ from app.config import CONFIG,config
 from app.manager import restart_task,init_shared_state
 
 def setup_logger():
+    """
+    配置全局日志记录器，支持文件轮转和控制台输出。
+    """
     logger = logging.getLogger()
     logger.setLevel(config.log.level)
     file_handler = RotatingFileHandler(
@@ -16,18 +19,19 @@ def setup_logger():
         encoding='utf-8'  # 添加UTF-8编码
     )
     file_handler.setFormatter(logging.Formatter(config.log.format))
-    
     # 添加控制台处理器
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter(config.log.format))
     console_handler.setLevel(config.log.level)
-    
     # 添加到logger
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
     return logger
 
 def mkdir():
+    """
+    创建数据和日志目录（如不存在）。
+    """
     if not os.path.exists('./databuf'):
         os.mkdir('./databuf')
     if not os.path.exists(config.log.folder):
@@ -35,6 +39,9 @@ def mkdir():
 
 
 def create_app():
+    """
+    Flask应用工厂，初始化应用、日志、蓝图和全局状态。
+    """
     app = Flask(__name__)
     app.secret_key = config.general.secretkey
     
@@ -46,6 +53,7 @@ def create_app():
 
     @app.errorhandler(404)
     def global_404(e):
+        """全局404错误处理。"""
         return render_template('404.html'), 404
     
     # 注册蓝图

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,4 +95,13 @@ def create_app():
         sys.exit(0)
     signal.signal(signal.SIGTERM, _global_shutdown)
     signal.signal(signal.SIGINT, _global_shutdown)
+
+    # 启动榜单任务清理线程（只启动一次）
+    try:
+        from app.services.standing import start_standing_task_cleanup
+        start_standing_task_cleanup()
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error(f"启动榜单任务清理线程失败: {e}")
+
     return app

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from box import Box
 from typing import cast
 
+# 加载YAML配置为字典
 CONFIG = cast(dict,yaml.safe_load(Path('config.yaml').read_text()))
 
+# 转为Box对象，支持点操作
 config = cast(Box, Box(CONFIG))  # type: ignore

--- a/app/models.py
+++ b/app/models.py
@@ -10,10 +10,7 @@ from app.config import CONFIG,config
 
 logger = logging.getLogger(__name__)
 
-class SaveDict(MutableMapping):
-    """
-    线程安全的字典，支持定时自动保存到磁盘。
-    """
+class SaveDict(MutableMapping):#线程安全&保存
     def __init__(self, name: str, filepath: str, interval_minutes: float = config.models.save_minute):
         self.name = name
         self.filepath = filepath
@@ -21,9 +18,9 @@ class SaveDict(MutableMapping):
         self._lock = threading.RLock()
         self._stop_event = threading.Event()
         self._interval = timedelta(minutes=interval_minutes).total_seconds()
-        # 加载已有数据
+        
         self._load_data()
-        # 启动后台保存线程
+        # 启动后台线程，延迟 interval 后首次保存
         self._thread = threading.Thread(target=self._run_saver, daemon=True)
         self._thread.start()
         self._isclosed = False
@@ -53,7 +50,7 @@ class SaveDict(MutableMapping):
         with self._lock:
             return key in self._data
 
-    # 其他可选扩展方法
+    # —— 其他可选扩展方法 —— #
     def clear(self):
         with self._lock:
             self._data.clear()

--- a/app/models.py
+++ b/app/models.py
@@ -10,7 +10,10 @@ from app.config import CONFIG,config
 
 logger = logging.getLogger(__name__)
 
-class SaveDict(MutableMapping):#线程安全&保存
+class SaveDict(MutableMapping):
+    """
+    线程安全的字典，支持定时自动保存到磁盘。
+    """
     def __init__(self, name: str, filepath: str, interval_minutes: float = config.models.save_minute):
         self.name = name
         self.filepath = filepath
@@ -18,9 +21,9 @@ class SaveDict(MutableMapping):#线程安全&保存
         self._lock = threading.RLock()
         self._stop_event = threading.Event()
         self._interval = timedelta(minutes=interval_minutes).total_seconds()
-        
+        # 加载已有数据
         self._load_data()
-        # 启动后台线程，延迟 interval 后首次保存
+        # 启动后台保存线程
         self._thread = threading.Thread(target=self._run_saver, daemon=True)
         self._thread.start()
         self._isclosed = False
@@ -50,7 +53,7 @@ class SaveDict(MutableMapping):#线程安全&保存
         with self._lock:
             return key in self._data
 
-    # —— 其他可选扩展方法 —— #
+    # 其他可选扩展方法
     def clear(self):
         with self._lock:
             self._data.clear()

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -2,9 +2,11 @@ from .api import api_bp
 from .main import main_bp
 from .tasks import tasks_bp
 from .standing_api import standing_api_bp  # 新增榜单任务API蓝图
+from .standing import bp  # 导入 standing.py 中的 bp 蓝图
 
 def register_routes(app):
     app.register_blueprint(api_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(tasks_bp)
     app.register_blueprint(standing_api_bp)  # 注册榜单任务API蓝图
+    app.register_blueprint(bp)  # 注册 standing.py 中的 bp 蓝图，使 /standing/create 路由生效

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,8 +1,10 @@
 from .api import api_bp
 from .main import main_bp
 from .tasks import tasks_bp
+from .standing_api import standing_api_bp  # 新增榜单任务API蓝图
 
 def register_routes(app):
     app.register_blueprint(api_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(tasks_bp)
+    app.register_blueprint(standing_api_bp)  # 注册榜单任务API蓝图

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -2,11 +2,11 @@ from .api import api_bp
 from .main import main_bp
 from .tasks import tasks_bp
 from .standing_api import standing_api_bp  # 新增榜单任务API蓝图
-from .standing import bp  # 导入 standing.py 中的 bp 蓝图
+from .standing import standing_bp  # 导入 standing.py 中的 bp 蓝图
 
 def register_routes(app):
     app.register_blueprint(api_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(tasks_bp)
     app.register_blueprint(standing_api_bp)  # 注册榜单任务API蓝图
-    app.register_blueprint(bp)  # 注册 standing.py 中的 bp 蓝图，使 /standing/create 路由生效
+    app.register_blueprint(standing_bp)  # 注册 standing.py 中的 bp 蓝图，

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -4,8 +4,10 @@ import time
 import app.manager
 from app.config import CONFIG,config
 
+# 创建API蓝图
 api_bp = Blueprint('api', __name__)
 
+# 获取所有任务的API接口
 @api_bp.route("/api/tasks")
 def get_tasks():
     tasks = []
@@ -21,13 +23,16 @@ def get_tasks():
             "contest_id": task.contest_id,
             "remaining": round(config.task.savetime - (time.time() - task.donetime), 2)
         })
+    # 按剩余保存时间降序排序
     tasks.sort(key=lambda x: x["remaining"], reverse=True)
     return jsonify(tasks=tasks, tottime=config.task.savetime)
 
+# 恢复任务API
 @api_bp.route("/api/task/<task_id>/resume", methods=["POST"])
 def api_resume_task(task_id):
     return app.manager.resume_task(task_id)
 
+# 暂停任务API
 @api_bp.route("/api/task/<task_id>/pause", methods=["POST"])
 def api_pause_task(task_id):
     return app.manager.pause_task(task_id)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -7,13 +7,16 @@ import json
 import app.manager
 from app.config import CONFIG,config
 
+# 创建主蓝图
 main_bp = Blueprint('main', __name__)
 logger = logging.getLogger(__name__)
 
+# 首页路由，处理表单提交和首页渲染
 @main_bp.route("/", methods=["GET", "POST"])
 def index():
     if request.method == "POST":
         try:
+            # 获取表单参数并启动任务
             start_id = int(request.form["start_id"])
             end_id = int(request.form["end_id"])
             cid = int(request.form["cid"])
@@ -22,6 +25,7 @@ def index():
             return "请输入三个整数！"
     return render_template("index.html", error=False)
 
+# 重试查询路由
 @main_bp.route("/retry", methods=["POST"])
 def retry():
     try:
@@ -33,10 +37,12 @@ def retry():
     else:
         return app.manager.start_task(start_id, end_id, cid)
 
+# 等待页面
 @main_bp.route("/waiting")
 def waiting():
     return render_template(config.general.waitingfile)
 
+# 查询进度接口，返回当前任务进度信息
 @main_bp.route("/progress")
 def progress():
     task_id = session.get('task_id')
@@ -54,6 +60,7 @@ def progress():
         })
     return json.dumps({"progress": 0, "status": "not_started"})
 
+# 结果页面，展示任务结果
 @main_bp.route("/result")
 def result():
     task_id = session.get('task_id')

--- a/app/routes/standing.py
+++ b/app/routes/standing.py
@@ -1,11 +1,12 @@
 # 榜单任务API接口
-from flask import Blueprint, request, jsonify, render_template
+from flask import Blueprint, request, jsonify, render_template, Response
 from app.services.standing import StandingTask, standing_task_manager, standing_get, standing_valid, standing_push
 from app.services.down import create_session, get_contest_problems, get_cache, process_single_submission
 # from app.services.anal import anal, ren
 import app.services.anal as anal
 import app.services.ren as ren
 import uuid
+import json
 
 standing_bp = Blueprint('standing', __name__)
 task_manager = standing_task_manager
@@ -39,7 +40,7 @@ def create_task():
         contest_id = int(data['contest_id'])
     except (KeyError, ValueError, TypeError):
         return jsonify({'success': False, 'message': '参数错误'}), 400
-    task_id = f"{contest_id}_{start_id}_{end_id}_{str(uuid.uuid4().replace('-','_'))}"
+    task_id = f"{contest_id}_{start_id}_{end_id}_{str(uuid.uuid4()).replace('-','_')}"
     if task_id in task_manager.tasks:
         return jsonify({'success': False, 'message': '任务已存在'}), 400
     task = StandingTask(task_id, start_id, end_id, contest_id)
@@ -97,3 +98,102 @@ def get_task_data(task_id):
         'standing.html',
         **context
     )
+
+@standing_bp.route('/standing/stream/<task_id>')
+def stream_standing(task_id):
+    import time
+    task = task_manager.tasks.get(task_id)
+    if not task:
+        return Response('任务不存在', status=404)
+    # 如果任务已完成，直接推送一次最终数据并结束
+    if task.status == 'completed':
+        try:
+            df, name_list, submission_history = anal.run(task.results)
+            problem_map = get_problem_map(task.contest_id)
+            context = ren.run(
+                df, task.start_id, task.end_id, task.contest_id, name_list, submission_history, problem_map
+            )
+            timeline_data = context.get('timeline_data', [])
+            table_header = list(df.columns)
+            users = list(df['用户名']) if '用户名' in df.columns else []
+            problems = [col for col in df.columns if str(col).isdigit()]
+            data = {
+                'table_header': table_header,
+                'users': users,
+                'problems': problems,
+                'timeline_data': timeline_data,
+                'problem_map': problem_map,
+                'chart_data': context.get('chart_data', {}),
+                'submission_history': submission_history
+            }
+        except Exception as e:
+            data = {'error': f'分析失败: {e}'}
+        return Response(f"data: {json.dumps(data, ensure_ascii=False)}\n\n", mimetype='text/event-stream')
+    def event_stream():
+        last_version = -1
+        while True:
+            if hasattr(task, 'version'):
+                version = task.version
+            else:
+                version = len(task.results)
+            if version != last_version:
+                try:
+                    
+                    
+                    df, name_list, submission_history = anal.run(task.results)
+                    problem_map = get_problem_map(task.contest_id)
+                    context = ren.run(
+                        df, task.start_id, task.end_id, task.contest_id, name_list, submission_history, problem_map
+                    )
+                    timeline_data = context.get('timeline_data', [])
+                    # 构造结构化数据：表头、用户、题目、timeline_data
+                    table_header = list(df.columns)
+                    users = list(df['用户名']) if '用户名' in df.columns else []
+                    problems = [col for col in df.columns if str(col).isdigit()]
+                    data = {
+                        'table_header': table_header,
+                        'users': users,
+                        'problems': problems,
+                        'timeline_data': timeline_data,
+                        'problem_map': problem_map,
+                        'chart_data': context.get('chart_data', {}),
+                        'submission_history': submission_history
+                    }
+                except Exception as e:
+                    data = {'error': f'分析失败: {e}'}
+                yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+                last_version = version
+            if task.status == 'completed':
+                # 任务完成时再推送一次最终数据，确保前端能收到最终快照
+                try:
+                    df, name_list, submission_history = anal.run(task.results)
+                    problem_map = get_problem_map(task.contest_id)
+                    context = ren.run(
+                        df, task.start_id, task.end_id, task.contest_id, name_list, submission_history, problem_map
+                    )
+                    timeline_data = context.get('timeline_data', [])
+                    table_header = list(df.columns)
+                    users = list(df['用户名']) if '用户名' in df.columns else []
+                    problems = [col for col in df.columns if str(col).isdigit()]
+                    data = {
+                        'table_header': table_header,
+                        'users': users,
+                        'problems': problems,
+                        'timeline_data': timeline_data,
+                        'problem_map': problem_map,
+                        'chart_data': context.get('chart_data', {}),
+                        'submission_history': submission_history
+                    }
+                except Exception as e:
+                    data = {'error': f'分析失败: {e}'}
+                yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+                break
+            time.sleep(1)
+    return Response(event_stream(), mimetype='text/event-stream')
+
+@standing_bp.route('/standing/stream_view/<task_id>')
+def stream_view(task_id):
+    task = task_manager.tasks.get(task_id)
+    if not task:
+        return '任务不存在', 404
+    return render_template('new_standing.html', task_id=task_id, startid=task.start_id, endid=task.end_id, cid=task.contest_id)

--- a/app/routes/standing.py
+++ b/app/routes/standing.py
@@ -5,6 +5,7 @@ from app.services.down import create_session, get_contest_problems, get_cache, p
 # from app.services.anal import anal, ren
 import app.services.anal as anal
 import app.services.ren as ren
+import uuid
 
 standing_bp = Blueprint('standing', __name__)
 task_manager = standing_task_manager
@@ -38,7 +39,7 @@ def create_task():
         contest_id = int(data['contest_id'])
     except (KeyError, ValueError, TypeError):
         return jsonify({'success': False, 'message': '参数错误'}), 400
-    task_id = f"{contest_id}_{start_id}_{end_id}"
+    task_id = f"{contest_id}_{start_id}_{end_id}_{str(uuid.uuid4().replace('-','_'))}"
     if task_id in task_manager.tasks:
         return jsonify({'success': False, 'message': '任务已存在'}), 400
     task = StandingTask(task_id, start_id, end_id, contest_id)

--- a/app/routes/standing.py
+++ b/app/routes/standing.py
@@ -1,0 +1,62 @@
+# 榜单任务API接口
+from flask import Blueprint, request, jsonify
+from app.services.standing import StandingTask, StandingTaskManager
+
+bp = Blueprint('standing', __name__)
+task_manager = StandingTaskManager(max_running=3)
+
+def dummy_get(id, contest_id):
+    # TODO: 实现实际的get逻辑
+    return {}
+
+def dummy_valid(result):
+    # TODO: 实现实际的valid逻辑
+    return True
+
+def dummy_push(results, result):
+    results.append(result)
+
+@bp.route('/standing/create', methods=['POST'])
+def create_task():
+    data = request.json
+    start_id = data['start_id']
+    end_id = data['end_id']
+    contest_id = data['contest_id']
+    task_id = f"{contest_id}_{start_id}_{end_id}"
+    task = StandingTask(task_id, start_id, end_id, contest_id)
+    task_manager.add_task(task)
+    return jsonify({'task_id': task_id, 'status': task.status})
+
+@bp.route('/standing/start/<task_id>', methods=['POST'])
+def start_task(task_id):
+    task_manager.start_task(task_id, dummy_get, dummy_valid, dummy_push)
+    return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
+
+@bp.route('/standing/pause/<task_id>', methods=['POST'])
+def pause_task(task_id):
+    task_manager.pause_task(task_id)
+    return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
+
+@bp.route('/standing/cancel/<task_id>', methods=['POST'])
+def cancel_task(task_id):
+    task_manager.cancel_task(task_id)
+    return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
+
+@bp.route('/standing/delete/<task_id>', methods=['POST'])
+def delete_task(task_id):
+    task_manager.delete_task(task_id)
+    return jsonify({'task_id': task_id, 'status': 'deleted'})
+
+@bp.route('/standing/list', methods=['GET'])
+def list_tasks():
+    return jsonify([
+        {'task_id': t.task_id, 'status': t.status, 'progress': t.current_id, 'end_id': t.end_id, 'contest_id': t.contest_id}
+        for t in task_manager.tasks.values()
+    ])
+
+@bp.route('/standing/data/<task_id>', methods=['GET'])
+def get_task_data(task_id):
+    task = task_manager.tasks.get(task_id)
+    if not task:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify({'results': task.results, 'status': task.status})

--- a/app/routes/standing.py
+++ b/app/routes/standing.py
@@ -1,35 +1,50 @@
 # 榜单任务API接口
 from flask import Blueprint, request, jsonify
-from app.services.standing import StandingTask, StandingTaskManager
+from app.services.standing import StandingTask, standing_task_manager, standing_get, standing_valid, standing_push
+from app.services.down import create_session, get_contest_problems, get_cache, process_single_submission
 
 bp = Blueprint('standing', __name__)
-task_manager = StandingTaskManager(max_running=3)
+task_manager = standing_task_manager
 
-def dummy_get(id, contest_id):
-    # TODO: 实现实际的get逻辑
-    return {}
+# 全局只初始化一次，避免重复请求
+_standing_session = create_session()
+_standing_cache = get_cache()
 
-def dummy_valid(result):
-    # TODO: 实现实际的valid逻辑
-    return True
+# contest_id -> problem_map 缓存
+_problem_map_cache = {}
+def get_problem_map(contest_id):
+    if contest_id not in _problem_map_cache:
+        _problem_map_cache[contest_id] = get_contest_problems(_standing_session, contest_id) or {}
+    return _problem_map_cache[contest_id]
 
-def dummy_push(results, result):
-    results.append(result)
+def real_get(submission_id, contest_id):
+    problem_map = get_problem_map(contest_id)
+    result, status = process_single_submission(_standing_session, submission_id, contest_id, _standing_cache, problem_map)
+    if status == 'not_found':
+        return 404
+    if status != 'ok':
+        return None
+    return result
 
 @bp.route('/standing/create', methods=['POST'])
 def create_task():
     data = request.json
-    start_id = data['start_id']
-    end_id = data['end_id']
-    contest_id = data['contest_id']
+    try:
+        start_id = int(data['start_id'])
+        end_id = int(data['end_id'])
+        contest_id = int(data['contest_id'])
+    except (KeyError, ValueError, TypeError):
+        return jsonify({'success': False, 'message': '参数错误'}), 400
     task_id = f"{contest_id}_{start_id}_{end_id}"
+    if task_id in task_manager.tasks:
+        return jsonify({'success': False, 'message': '任务已存在'}), 400
     task = StandingTask(task_id, start_id, end_id, contest_id)
     task_manager.add_task(task)
-    return jsonify({'task_id': task_id, 'status': task.status})
+    return jsonify({'success': True, 'task_id': task_id, 'status': task.status})
 
 @bp.route('/standing/start/<task_id>', methods=['POST'])
 def start_task(task_id):
-    task_manager.start_task(task_id, dummy_get, dummy_valid, dummy_push)
+    task_manager.start_task(task_id)
     return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
 
 @bp.route('/standing/pause/<task_id>', methods=['POST'])

--- a/app/routes/standing.py
+++ b/app/routes/standing.py
@@ -6,7 +6,7 @@ from app.services.down import create_session, get_contest_problems, get_cache, p
 import app.services.anal as anal
 import app.services.ren as ren
 
-bp = Blueprint('standing', __name__)
+standing_bp = Blueprint('standing', __name__)
 task_manager = standing_task_manager
 
 # 全局只初始化一次，避免重复请求
@@ -29,7 +29,7 @@ def real_get(submission_id, contest_id):
         return None
     return result
 
-@bp.route('/standing/create', methods=['POST'])
+@standing_bp.route('/standing/create', methods=['POST'])
 def create_task():
     data = request.json
     try:
@@ -45,34 +45,34 @@ def create_task():
     task_manager.add_task(task)
     return jsonify({'success': True, 'task_id': task_id, 'status': task.status})
 
-@bp.route('/standing/start/<task_id>', methods=['POST'])
+@standing_bp.route('/standing/start/<task_id>', methods=['POST'])
 def start_task(task_id):
     task_manager.start_task(task_id)
     return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
 
-@bp.route('/standing/pause/<task_id>', methods=['POST'])
+@standing_bp.route('/standing/pause/<task_id>', methods=['POST'])
 def pause_task(task_id):
     task_manager.pause_task(task_id)
     return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
 
-@bp.route('/standing/cancel/<task_id>', methods=['POST'])
+@standing_bp.route('/standing/cancel/<task_id>', methods=['POST'])
 def cancel_task(task_id):
     task_manager.cancel_task(task_id)
     return jsonify({'task_id': task_id, 'status': task_manager.tasks[task_id].status})
 
-@bp.route('/standing/delete/<task_id>', methods=['POST'])
+@standing_bp.route('/standing/delete/<task_id>', methods=['POST'])
 def delete_task(task_id):
     task_manager.delete_task(task_id)
     return jsonify({'task_id': task_id, 'status': 'deleted'})
 
-@bp.route('/standing/list', methods=['GET'])
+@standing_bp.route('/standing/list', methods=['GET'])
 def list_tasks():
     return jsonify([
         {'task_id': t.task_id, 'status': t.status, 'progress': t.current_id, 'end_id': t.end_id, 'contest_id': t.contest_id}
         for t in task_manager.tasks.values()
     ])
 
-@bp.route('/standing/data/<task_id>', methods=['GET'])
+@standing_bp.route('/standing/data/<task_id>', methods=['GET'])
 def get_task_data(task_id):
     task = task_manager.tasks.get(task_id)
     if not task:

--- a/app/routes/standing_api.py
+++ b/app/routes/standing_api.py
@@ -1,9 +1,7 @@
 from flask import Blueprint, jsonify
-from app.services.standing import StandingTaskManager
-
-# 实例化榜单任务管理器（与 standing.py 保持一致）
+from app.services.standing import standing_task_manager
 standing_api_bp = Blueprint('standing_api', __name__)
-task_manager = StandingTaskManager()
+task_manager = standing_task_manager
 
 @standing_api_bp.route('/api/standing_tasks')
 def get_standing_tasks():

--- a/app/routes/standing_api.py
+++ b/app/routes/standing_api.py
@@ -12,6 +12,7 @@ def get_standing_tasks():
         total = max(1, task.end_id - task.start_id + 1)
         progress = min(100, round((task.current_id - task.start_id) / total * 100))
         remaining_time = task.remaining_time() if hasattr(task, 'remaining_time') else 0
+        print(time.time(),task.done_time,config.task.savetime, max(0,config.task.savetime-(time.time()-task.done_time)))
         tasks.append({
             'id': task.task_id,
             'status': task.status,

--- a/app/routes/standing_api.py
+++ b/app/routes/standing_api.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, jsonify
+from app.services.standing import StandingTaskManager
+
+# 实例化榜单任务管理器（与 standing.py 保持一致）
+standing_api_bp = Blueprint('standing_api', __name__)
+task_manager = StandingTaskManager()
+
+@standing_api_bp.route('/api/standing_tasks')
+def get_standing_tasks():
+    tasks = []
+    for task in task_manager.tasks.values():
+        tasks.append({
+            'id': task.task_id,
+            'status': task.status,
+            'progress': task.current_id - task.start_id,
+            'start': task.start_id,
+            'end': task.end_id,
+            'current': task.current_id,
+            'contest_id': task.contest_id
+        })
+    return jsonify(tasks=tasks)

--- a/app/routes/standing_api.py
+++ b/app/routes/standing_api.py
@@ -1,5 +1,7 @@
 from flask import Blueprint, jsonify
 from app.services.standing import standing_task_manager
+import time
+from app.config import config
 standing_api_bp = Blueprint('standing_api', __name__)
 task_manager = standing_task_manager
 
@@ -7,13 +9,18 @@ task_manager = standing_task_manager
 def get_standing_tasks():
     tasks = []
     for task in task_manager.tasks.values():
+        total = max(1, task.end_id - task.start_id + 1)
+        progress = min(100, round((task.current_id - task.start_id) / total * 100))
+        remaining_time = task.remaining_time() if hasattr(task, 'remaining_time') else 0
         tasks.append({
             'id': task.task_id,
             'status': task.status,
-            'progress': task.current_id - task.start_id,
+            'progress': progress,
             'start': task.start_id,
             'end': task.end_id,
             'current': task.current_id,
-            'contest_id': task.contest_id
+            'contest_id': task.contest_id,
+            'remaining': max(0,config.task.savetime-(time.time()-task.done_time))
         })
+        
     return jsonify(tasks=tasks)

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -5,9 +5,11 @@ import logging
 import app.manager
 from app.config import CONFIG,config
 
+# 创建任务相关蓝图
 tasks_bp = Blueprint('tasks', __name__)
 logger = logging.getLogger(__name__)
 
+# 任务列表页面，展示所有任务
 @tasks_bp.route("/tasklist")
 def task_list():
     tasks = []
@@ -22,19 +24,21 @@ def task_list():
             "current": task.current,
             "remaining": round(config.task.savetime - (time.time() - task.donetime), 2)
         })
+    # 按剩余保存时间降序排序
     tasks.sort(key=lambda x: x["remaining"], reverse=True)
     logger.info(f"有用户试图访问tasklist，共{len(tasks)} 个数据")
     return render_template("tasklist.html", tasks=tasks, tottime=config.task.savetime)
 
+# 选择任务，设置session
 @tasks_bp.route("/selecttask", methods=["POST"])
 def select_task():
     task_id = request.form.get("task_id")
     if task_id not in app.manager.tasks:
         abort(404)
-    
     session['task_id'] = task_id
     return redirect(url_for("main.waiting"))
 
+# 取消任务接口
 @tasks_bp.route("/cancel", methods=["POST"])
 def cancel_task_session():
     task_id = session.get('task_id')
@@ -43,6 +47,7 @@ def cancel_task_session():
         return jsonify(success=False, message="未找到任务ID")
     return app.manager.cancel_task(task_id)
 
+# 暂停任务接口
 @tasks_bp.route("/pause", methods=["POST"])
 def pause_task_session():
     task_id = session.get('task_id')
@@ -51,6 +56,7 @@ def pause_task_session():
         return jsonify(success=False, message="未找到任务ID")
     return app.manager.pause_task(task_id)
 
+# 恢复任务接口
 @tasks_bp.route("/resume", methods=["POST"])
 def resume_task_session():
     task_id = session.get('task_id')

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,8 +1,8 @@
 import logging
 
-from .down import run as down
-from .ren import run as ren
-from .anal import run as anal
+from .down import run as downrun
+from .ren import run as renrun
+from .anal import run as analrun
 import requests
 
 logger = logging.getLogger(__name__)
@@ -10,15 +10,15 @@ logger = logging.getLogger(__name__)
 def run(start_id, end_id, cid, task_id, progress_callback=None,should_cancel=None,should_pause=None):
     logger.info(f"任务 {task_id} 开始获得数据")
     # 1. 获取提交数据
-    status,submission_data,problem_map = down(start_id, end_id, cid, task_id, progress_callback,should_cancel,should_pause)
+    status,submission_data,problem_map = downrun(start_id, end_id, cid, task_id, progress_callback,should_cancel,should_pause)
     if status != 'completed':
         return status,''
     
     logger.info(f"任务 {task_id} 开始分析数据")
     # 2. 分析数据生成DataFrame
-    df, name_order, submission_history = anal(submission_data)
+    df, name_order, submission_history = analrun(submission_data)
     
     logger.info(f"任务 {task_id} 开始生成 html context")
     # 3. 渲染HTML context
-    context = ren(df, start_id,end_id,cid,name_order, submission_history, problem_map)
+    context = renrun(df, start_id,end_id,cid,name_order, submission_history, problem_map)
     return 'completed', context

--- a/app/services/anal.py
+++ b/app/services/anal.py
@@ -2,9 +2,13 @@ from collections import defaultdict
 import pandas as pd
 import logging
 
+# 获取日志记录器
 logger = logging.getLogger(__name__)
 
 def run(submission_data):
+    """
+    入口函数：处理提交数据，生成DataFrame、用户名列表和提交历史。
+    """
     if not submission_data:
         logger.warning("收到空提交数据")
         return pd.DataFrame(), [], {}
@@ -41,7 +45,7 @@ def run(submission_data):
         # 记录提交历史
         submission_history[username][problem_id].append((submission_id, score_val))
     
-    # 创建DataFrame
+    # 创建DataFrame数据
     df_data = []
     for problem_id, user_scores in problem_scores.items():
         row = [problem_id]

--- a/app/services/down.py
+++ b/app/services/down.py
@@ -12,12 +12,14 @@ from functools import lru_cache
 
 from app.config import CONFIG
 
+# 获取日志记录器
 logger = logging.getLogger(__name__)
 
 def create_session():
-    """创建并配置具有重试机制和连接池的请求会话"""
+    """
+    创建并配置具有重试机制和连接池的请求会话。
+    """
     session = requests.Session()
-    
     # 配置重试策略
     retry_config = CONFIG['down']['retry']
     retry_strategy = Retry(
@@ -25,31 +27,27 @@ def create_session():
         backoff_factor=retry_config['backoff_factor'],
         status_forcelist=retry_config['status_forcelist']
     )
-    
     # 配置连接池
     adapter = HTTPAdapter(max_retries=retry_strategy)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-    
     # 设置请求头
     session.headers.update(CONFIG['down']['headers'])
-    
     # 设置cookies
     if CONFIG['down']['cookies']:
         session.cookies.update(CONFIG['down']['cookies'])
     else:
         logger.warning("没有设置 cookies")
-    
     return session
 
 def get_contest_problems(session, contest_id):
-    """获取比赛中的所有问题ID和题目名称"""
+    """
+    获取比赛中的所有问题ID和题目名称。
+    """
     url = f"http://oj.daimayuan.top/contest/{contest_id}"
     response = session.get(url)
-
     if response.status_code != 200:
         return None
-    
     soup = BeautifulSoup(response.text, 'html.parser')
     problem_map = dict()
     for tr in soup.select('table tbody tr'):
@@ -73,7 +71,6 @@ def get_cache():
     cache_dir = CONFIG['general']['cache_dir']
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
-    
     cache_config = CONFIG['down']['cache']
     return Cache(
         cache_dir,

--- a/app/services/ren.py
+++ b/app/services/ren.py
@@ -4,13 +4,15 @@ import logging
 
 from app.config import CONFIG, config
 
-
+# 获取日志记录器
 logger = logging.getLogger(__name__)
-def run(df, startid, endid, cid, name_order, submission_history, problem_map):
 
+def run(df, startid, endid, cid, name_order, submission_history, problem_map):
+    """
+    入口函数：处理数据并生成 standing.html 所需 context。
+    """
     df = prepare_data(df)
     df_sorted = sort_and_rank(df)
-    
     # 处理时间轴数据
     timeline_data = []
     for username, problems in submission_history.items():
@@ -23,22 +25,27 @@ def run(df, startid, endid, cid, name_order, submission_history, problem_map):
                     'problemId': str(problem_id),
                     'score': score
                 })
-    
     # 按提交ID排序
     timeline_data.sort(key=lambda x: x['time'])
-    
+    # 渲染表格HTML
     table_html = render_table(df_sorted, name_order, submission_history, problem_map)
+    # 构建context字典
     context = build_html(table_html, startid, endid, cid, timeline_data)
     logger.info(f"{startid},{endid},{cid},已生成 HTML context")
     return context
 
-
 def prepare_data(df):
+    """
+    预处理数据，计算总分。
+    """
     df = df.copy()
     df['总分'] = df.iloc[:, 1:-1].sum(axis=1)
     return df
 
 def sort_and_rank(df):
+    """
+    按总分降序排序并添加排名列。
+    """
     df = df.sort_values('总分', ascending=False)
     df.insert(0, '排名', range(1, len(df) + 1))
     return df
@@ -56,7 +63,9 @@ def build_html(table_html, startid, endid, cid, timeline_data):
     }
 
 def render_table(df, name_order, submission_history, problem_map):
-    """渲染表格为HTML"""
+    """
+    渲染成绩表格为HTML。
+    """
     html = []
     html.append('<table id="rank-table" class="table table-hover">')
     

--- a/app/services/standing.py
+++ b/app/services/standing.py
@@ -145,9 +145,10 @@ class StandingTaskManager:
         # 自动保存由 SaveDict 后台线程负责
 
     def _run_loop(self):
+        interval = getattr(config.task, 'push_interval', 1)
         while not self._stop_event.is_set():
             self.step_all()
-            time.sleep(1)
+            time.sleep(interval)
 
     def handle_exit(self, signum, frame):
         for task in self.tasks.values():

--- a/app/services/standing.py
+++ b/app/services/standing.py
@@ -1,0 +1,104 @@
+# 榜单任务管理与执行逻辑（SaveDict用于任务池，任务为普通对象）
+from app.models import SaveDict
+import signal
+
+class StandingTask:
+    def __init__(self, task_id, start_id, end_id, contest_id):
+        self.task_id = task_id
+        self.start_id = start_id
+        self.end_id = end_id
+        self.contest_id = contest_id
+        self.status = 'pending'  # running, paused, finished, cancelled
+        self.current_id = start_id
+        self.results = []
+
+    def to_dict(self):
+        return {
+            'task_id': self.task_id,
+            'start_id': self.start_id,
+            'end_id': self.end_id,
+            'contest_id': self.contest_id,
+            'status': self.status,
+            'current_id': self.current_id,
+            'results': self.results,
+        }
+
+    @classmethod
+    def from_dict(cls, d):
+        obj = cls(d['task_id'], d['start_id'], d['end_id'], d['contest_id'])
+        obj.status = d.get('status', 'pending')
+        obj.current_id = d.get('current_id', d['start_id'])
+        obj.results = d.get('results', [])
+        return obj
+
+    def step(self, get_func, valid_func, push_func, should_pause_func=None):
+        if self.status != 'running':
+            return
+        if should_pause_func and should_pause_func(self):
+            self.status = 'paused'
+            return
+        if self.current_id > self.end_id:
+            self.status = 'finished'
+            return
+        result = get_func(self.current_id, self.contest_id)
+        if result != 404 and valid_func(result):
+            push_func(self.results, result)
+        self.current_id += 1
+        if self.current_id > self.end_id:
+            self.status = 'finished'
+
+    def pause(self):
+        if self.status == 'running':
+            self.status = 'paused'
+
+    def resume(self):
+        if self.status == 'paused':
+            self.status = 'running'
+
+    def cancel(self):
+        self.status = 'cancelled'
+
+class StandingTaskManager:
+    def __init__(self, save_name='standing_tasks'):
+        self.tasks = SaveDict(save_name, f'cache/{save_name}.pkl')
+        signal.signal(signal.SIGTERM, self.handle_exit)
+        signal.signal(signal.SIGINT, self.handle_exit)
+        # 恢复任务对象
+        for k, v in list(self.tasks.items()):
+            if not isinstance(v, StandingTask):
+                self.tasks[k] = StandingTask.from_dict(v)
+
+    def add_task(self, task):
+        self.tasks[task.task_id] = task
+
+    def start_task(self, task_id):
+        task = self.tasks.get(task_id)
+        if not task or task.status not in ['pending', 'paused']:
+            return
+        task.status = 'running'
+
+    def pause_task(self, task_id):
+        task = self.tasks.get(task_id)
+        if task and task.status == 'running':
+            task.pause()
+
+    def cancel_task(self, task_id):
+        task = self.tasks.get(task_id)
+        if task:
+            task.cancel()
+
+    def delete_task(self, task_id):
+        if task_id in self.tasks:
+            del self.tasks[task_id]
+
+    def step_all(self, get_func, valid_func, push_func, should_pause_func=None):
+        for task in self.tasks.values():
+            if task.status == 'running':
+                task.step(get_func, valid_func, push_func, should_pause_func)
+
+    def handle_exit(self, signum, frame):
+        for task in self.tasks.values():
+            if task.status == 'running':
+                task.pause()
+        print('StandingTaskManager: graceful shutdown')
+        self.tasks.close()

--- a/app/static/css/404.css
+++ b/app/static/css/404.css
@@ -1,3 +1,6 @@
+/* 404页面样式 */
+
+/* 页面基础布局与字体设置 */
 body {
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to right, #e0eafc, #cfdef3);
@@ -7,6 +10,8 @@ body {
     height: 100vh;
     margin: 0;
 }
+
+/* 错误容器样式 */
 .error-container {
     text-align: center;
     padding: 40px;
@@ -15,6 +20,8 @@ body {
     border-radius: 12px;
     box-shadow: 0 8px 30px rgba(0,0,0,0.1);
 }
+
+/* 错误码样式 */
 .error-code {
     font-size: 100px;
     font-weight: bold;
@@ -22,11 +29,15 @@ body {
     margin-bottom: 20px;
     letter-spacing: 8px;
 }
+
+/* 错误信息样式 */
 .error-message {
     font-size: 24px;
     color: #333;
     margin-bottom: 30px;
 }
+
+/* 返回首页按钮样式 */
 .home-link {
     display: inline-block;
     padding: 12px 30px;
@@ -36,6 +47,7 @@ body {
     border-radius: 6px;
     transition: background-color 0.3s ease;
 }
+
 .home-link:hover {
     background-color: #0056b3;
 }

--- a/app/static/css/index.css
+++ b/app/static/css/index.css
@@ -1,4 +1,6 @@
+/* index.css: 首页样式 */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+/* 页面基础布局与字体设置 */
 body {
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to right, #e0eafc, #cfdef3);
@@ -8,6 +10,7 @@ body {
     height: 100vh;
     margin: 0;
 }
+/* 主容器样式 */
 .container {
     background-color: white;
     padding: 40px;

--- a/app/static/css/standing.css
+++ b/app/static/css/standing.css
@@ -682,7 +682,7 @@ input:checked + .slider:before {
 }
 @keyframes scoreChange {
   0% { background-color: transparent; }
-  10%   { transform: scale(2);background-color: rgb(246, 255, 0); }
+  10%   { transform: scale(2); background-color: transparent; }
   100% { background-color: transparent; }
 }
 .score-change {
@@ -701,4 +701,33 @@ input:checked + .slider:before {
     width: 100%;
     justify-content: center;
   }
+}
+
+/* standing-btn: 兼容 standing 页风格的自定义按钮 */
+.standing-btn {
+  display: inline-block;
+  padding: 8px 28px;
+  background: var(--card-bg, #fff);
+  border: 1.5px solid var(--primary-color, #2c6fbb);
+  border-radius: 8px;
+  color: var(--primary-color, #2c6fbb);
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 8px rgba(44,111,187,0.04);
+  text-decoration: none;
+  outline: none;
+}
+.standing-btn:hover, .standing-btn:focus {
+  background: var(--primary-color, #2c6fbb);
+  color: #fff;
+  border-color: var(--primary-color, #2c6fbb);
+  box-shadow: 0 4px 16px rgba(44,111,187,0.10);
+  text-decoration: none;
+}
+.standing-btn:active {
+  background: var(--secondary-color, #3498db);
+  color: #fff;
+  border-color: var(--secondary-color, #3498db);
 }

--- a/app/static/css/standing.css
+++ b/app/static/css/standing.css
@@ -1,4 +1,6 @@
 /* standing.css: 完整提取自 standing.html 的 <style> 部分 */
+
+/* 主题色与全局变量定义 */
 :root {
   --primary-color: #2c6fbb;
   --secondary-color: #3498db;
@@ -9,6 +11,8 @@
   --text-color: #34495e;
   --card-bg: rgba(255, 255, 255, 0.95);
 }
+
+/* 页面基础布局与字体设置 */
 body {
   font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   padding: 20px;
@@ -20,6 +24,8 @@ body {
   align-items: center;
   margin: 0;
 }
+
+/* 主容器布局 */
 .main-container {
   max-width: 1200px;
   width: 100%;
@@ -28,6 +34,8 @@ body {
   flex-direction: column;
   gap: 20px;
 }
+
+/* 内容包裹层样式 */
 .content-wrapper {
   display: flex;
   flex-direction: column;
@@ -39,6 +47,8 @@ body {
   position: relative;
   overflow: hidden;
 }
+
+/* 顶部标题栏样式 */
 .header {
   background: var(--card-bg);
   color: var(--dark-color);
@@ -55,6 +65,8 @@ body {
   margin: 0;
   color: var(--primary-color);
 }
+
+/* 卡片通用样式 */
 .card {
   background-color: var(--card-bg);
   border-radius: 12px;
@@ -64,6 +76,8 @@ body {
   position: relative;
   z-index: 2;
 }
+
+/* 控件区样式 */
 .controls {
   display: flex;
   justify-content: space-between;
@@ -157,6 +171,8 @@ tbody tr {
 tbody tr:hover {
   background-color: #f0f8ff;
 }
+
+/* 统计区布局 */
 .stats-container {
   display: flex;
   flex-direction: column;
@@ -213,7 +229,8 @@ tbody tr:hover {
   position: relative;
   z-index: 2;
 }
-/* 排序指示器 */
+
+/* 排序指示器样式 */
 th[data-sort]::after {
   content: "↕";
   margin-left: 5px;
@@ -228,6 +245,7 @@ th[data-sort].sort-desc::after {
   content: "↓";
   opacity: 1;
 }
+
 /* 全屏模式样式 */
 body.fullscreen-mode {
   padding: 10px;
@@ -254,6 +272,7 @@ body.fullscreen-mode #exitFullscreen {
 body.fullscreen-mode #toggleFullscreen {
   display: none;
 }
+
 /* 响应式设计 */
 @media (max-width: 768px) {
   .stats-container {
@@ -286,6 +305,7 @@ body.fullscreen-mode #toggleFullscreen {
     padding: 15px;
   }
 }
+
 /* 分数单元格样式 */
 .score-cell {
   font-weight: 600;
@@ -337,7 +357,8 @@ tr:nth-child(3) .rank-cell {
   width: 0%;
   transition: width 0.5s ease;
 }
-/* 装饰元素 */
+
+/* 装饰元素样式 */
 .decor-element {
   position: absolute;
   z-index: 1;
@@ -361,7 +382,8 @@ tr:nth-child(3) .rank-cell {
   left: -100px;
   transform: rotate(45deg);
 }
-/* 提交历史样式 */
+
+/* 提交历史弹窗样式 */
 .submission-history {
   display: none;
   position: absolute;
@@ -404,6 +426,7 @@ tr:nth-child(3) .rank-cell {
 .score-cell:hover .submission-history {
   display: block;
 }
+
 /* 表格标题样式 */
 th {
   white-space: nowrap;
@@ -416,6 +439,7 @@ th:hover {
   white-space: normal;
   word-break: break-word;
 }
+
 /* 添加排序样式 */
 th.sort-asc::after {
   content: ' ↑';
@@ -425,6 +449,7 @@ th.sort-desc::after {
   content: ' ↓';
   color: #fff;
 }
+
 /* 分数列样式 */
 td[data-sort] {
   /* font-family: monospace; */
@@ -432,6 +457,7 @@ td[data-sort] {
   padding-right: 20px;
   font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
+
 /* 时间轴样式 */
 .timeline-container {
   margin-top: 20px;
@@ -513,6 +539,7 @@ td[data-sort] {
   font-size: 14px;
   margin-top: 10px;
 }
+
 /* 响应式调整 */
 @media (max-width: 768px) {
   .timeline-controls {
@@ -529,7 +556,8 @@ td[data-sort] {
     gap: 5px;
   }
 }
-/* 速度控制样式 */
+
+/* 播放速度控制样式 */
 .speed-control {
   display: flex;
   align-items: center;
@@ -553,6 +581,7 @@ td[data-sort] {
   border-color: var(--secondary-color);
   box-shadow: 0 0 0 0.2rem rgba(52, 152, 219, 0.2);
 }
+
 /* 播放按钮样式 */
 #playPauseBtn.playing {
   background-color: var(--accent-color);
@@ -560,6 +589,7 @@ td[data-sort] {
 #playPauseBtn.playing:hover {
   background-color: #c0392b;
 }
+
 /* 动画控制开关样式 */
 .animation-control {
   display: flex;
@@ -614,6 +644,7 @@ input:checked + .slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
 /* 排名变动动画样式 */
 @keyframes rankDown {
   0% {
@@ -658,6 +689,7 @@ input:checked + .slider:before {
   display: inline-block;  
   animation: scoreChange 0.45s ease-out;
 }
+
 /* 响应式调整 */
 @media (max-width: 768px) {
   .timeline-controls {

--- a/app/static/css/tasklist.css
+++ b/app/static/css/tasklist.css
@@ -143,6 +143,46 @@ h1::after {
     font-size: 14px;
 }
 
+/* 修复进度和剩余时间列抽动问题 */
+.task-progress-cell, .task-remaining-cell {
+    min-width: 90px;
+    max-width: 120px;
+    text-align: left;
+    font-family: inherit;
+    letter-spacing: 0;
+    white-space: nowrap;
+}
+
+.progress-align-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    min-width: 70px;
+    max-width: 120px;
+}
+
+.progress-percent {
+    min-width: 48px;
+    text-align: left;
+    font-variant-numeric: tabular-nums;
+    font-family: inherit;
+    margin-bottom: 2px;
+}
+
+.progress-container {
+    width: 100%;
+    min-width: 60px;
+    max-width: 120px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.task-progress-cell span, .task-remaining-cell span {
+    display: inline-block;
+    min-width: 48px;
+    text-align: left;
+}
+
 /* 状态徽章样式 */
 .status-badge {
     display: inline-block;

--- a/app/static/css/tasklist.css
+++ b/app/static/css/tasklist.css
@@ -1,4 +1,5 @@
 /* Task List Stylesheet */
+/* 字体与全局变量 */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 :root {
@@ -10,6 +11,7 @@
     --paused-color: #f731e7;
 }
 
+/* 页面基础布局 */
 body {
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to right, #e0eafc, #cfdef3) ;
@@ -18,6 +20,7 @@ body {
     min-height: 100vh;
 }
 
+/* 主容器样式 */
 .container {
     max-width: 1200px;
     margin: 0 auto;
@@ -51,6 +54,7 @@ h1::after {
     border-radius: 2px;
 }
 
+/* 控件区布局 */
 .controls {
     display: flex;
     justify-content: space-between;
@@ -59,6 +63,7 @@ h1::after {
     gap: 15px;
 }
 
+/* 筛选区样式 */
 .filter-section {
     display: flex;
     align-items: center;
@@ -108,6 +113,7 @@ h1::after {
     gap: 5px;
 }
 
+/* 任务表格样式 */
 .task-table {
     width: 100%;
     border-collapse: collapse;
@@ -137,6 +143,7 @@ h1::after {
     font-size: 14px;
 }
 
+/* 状态徽章样式 */
 .status-badge {
     display: inline-block;
     padding: 4px 10px;
@@ -170,6 +177,7 @@ h1::after {
     color: var(--paused-color);
 }
 
+/* 进度条样式 */
 .progress-container {
     width: 100%;
     height: 10px;
@@ -186,6 +194,7 @@ h1::after {
     transition: width 0.5s ease-in-out;
 }
 
+/* 操作按钮样式 */
 .action-btn {
     padding: 8px 15px;
     background-color: var(--primary-color);
@@ -251,6 +260,7 @@ h1::after {
     font-size: 14px;
 }
 
+/* 统计卡片样式 */
 .stats {
     display: flex;
     justify-content: space-around;
@@ -291,6 +301,7 @@ h1::after {
     color: var(--error-color);
 }
 
+/* 通知样式 */
 .notification {
     position: fixed;
     top: 20px;

--- a/app/static/css/waiting.css
+++ b/app/static/css/waiting.css
@@ -1,4 +1,6 @@
-/* waiting.css */
+/* waiting.css: 提取自 waiting.html 的样式 */
+
+/* 页面基础布局与字体设置 */
 body {
     font-family: 'Inter', sans-serif;
     background: linear-gradient(to right, #e0eafc, #cfdef3);
@@ -8,6 +10,8 @@ body {
     height: 100vh;
     margin: 0;
 }
+
+/* 主容器样式 */
 .container {
     background-color: white;
     padding: 40px;
@@ -17,8 +21,10 @@ body {
     width: 100%;
     text-align: center;
 }
+
+/* 进度条相关样式 */
 .progress-container {
-    margin: 30px 0;
+    margin: 30px 0; /* 上下外边距30px */
 }
 .progress-bar {
     height: 20px;
@@ -33,6 +39,8 @@ body {
     width: 0%;
     transition: width 0.5s ease;
 }
+
+/* 状态与信息文本样式 */
 .status-text {
     margin-top: 15px;
     font-size: 16px;
@@ -43,16 +51,18 @@ body {
     font-size: 14px;
     color: #777;
 }
-.cancel-btn, .home-btn ,.pause-btn,.resume-btn{
-    display: block;
-    margin: 20px auto 0;
-    padding: 12px 30px;
-    border: none;
-    border-radius: 6px;
-    font-size: 16px;
-    cursor: pointer;
-    transition: background-color 0.3s;
-    color: white;
+
+/* 按钮样式 */
+.cancel-btn, .home-btn, .pause-btn, .resume-btn {
+    display: block; /* 块级显示 */
+    margin: 20px auto 0; /* 上外边距20px，左右自动 */
+    padding: 12px 30px; /* 内边距12px 30px */
+    border: none; /* 无边框 */
+    border-radius: 6px; /* 边角圆润 */
+    font-size: 16px; /* 字体大小16px */
+    cursor: pointer; /* 鼠标指针样式 */
+    transition: background-color 0.3s; /* 背景色变化过渡 */
+    color: white; /* 字体颜色为白色 */
 }
 .cancel-btn {
     background-color: #e74c3c;

--- a/app/static/js/standing-anim.js
+++ b/app/static/js/standing-anim.js
@@ -1,0 +1,33 @@
+// standing-anim.js
+// 专门用于榜单排名变动动画的 JS 文件
+
+// 触发一次动画的工具函数
+function triggerAnimationOnce(el, className) {
+  if (!el || !className) return;
+  if (el.classList.contains(className)) return;
+  el.classList.remove(className); // 保证状态干净
+  requestAnimationFrame(() => {
+    el.classList.add(className);
+    el.addEventListener('animationend', () => {
+      el.classList.remove(className);
+    }, { once: true });
+  });
+}
+
+// 榜单排名动画应用函数
+function applyRankAnimation(rows, oldPositions, newRows) {
+  newRows.forEach((row, newIdx) => {
+    const username = row.querySelector('.username-cell').textContent;
+    const oldIdx = oldPositions.get(username);
+    if (oldIdx !== newIdx) {
+      const dist = (oldIdx - newIdx) * row.offsetHeight;
+      row.style.setProperty('--move-distance', `${dist}px`);
+      const className = oldIdx > newIdx ? 'rank-up' : 'rank-down';
+      const rankCell = row.querySelector('.rank-cell');
+      if (rankCell) triggerAnimationOnce(rankCell, className);
+    }
+  });
+}
+
+// 导出函数（如需模块化可用）
+window.standingAnim = { triggerAnimationOnce, applyRankAnimation };

--- a/app/static/js/standing.js
+++ b/app/static/js/standing.js
@@ -1,7 +1,8 @@
 document.getElementById('timestamp').textContent = new Date().toLocaleString();
 
-  document.addEventListener('DOMContentLoaded', function() {
-    // 自定义分数排序函数
+// DOMContentLoaded事件，初始化所有交互逻辑
+document.addEventListener('DOMContentLoaded', function() {
+    // 扩展Tablesort以支持分数排序
     Tablesort.extend('score', function(item) {
         return item.match(/^-?\d+$/);
     }, function(a, b) {
@@ -18,7 +19,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
         column: 0  // 默认按第一列排序
     });
 
-    // 添加表头点击事件
+    // 表头点击事件，切换排序标记
     document.querySelectorAll('th').forEach(th => {
         th.addEventListener('click', function() {
             // 移除其他表头的排序标记
@@ -30,7 +31,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
         });
     });
 
-    // 搜索功能
+    // 搜索功能，实时过滤用户名
     document.getElementById('searchInput').addEventListener('input', function(e) {
       const searchTerm = e.target.value.toLowerCase().trim();
       const rows = document.querySelectorAll('#rank-table tbody tr');
@@ -40,7 +41,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
       });
     });
 
-    // 提交历史交互
+    // 分数单元格点击，显示/隐藏提交历史
     document.querySelectorAll('.score-cell').forEach(cell => {
       const history = cell.querySelector('.submission-history');
       if (history) {
@@ -67,7 +68,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
       }
     });
 
-    // 分数颜色插值色带
+    // 分数颜色插值，渲染分数颜色
     const colorScale = chroma.scale(['#e74c3c', '#f39c12', '#27ae60']).domain([0, 50, 100]);
     document.querySelectorAll('#rank-table tbody td.score-cell').forEach(cell => {
       let scoreSpan = cell.querySelector('.score-text');
@@ -124,7 +125,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
       }
     });
 
-    // 初始化工具提示
+    // 初始化Bootstrap工具提示
     $(function () {
       $('[data-bs-toggle="tooltip"]').tooltip({
         trigger: 'hover',
@@ -132,7 +133,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
       });
     });
 
-    // 计算统计信息
+    // 统计信息计算与展示
     const scores = Array.from(document.querySelectorAll('#rank-table tbody td:last-child'))
       .map(td => parseFloat(td.textContent) || 0);
 
@@ -148,7 +149,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
         : (sortedScores[mid - 1] + sortedScores[mid]) / 2;
       document.getElementById('medianScore').textContent = median.toFixed(1);
       
-      // 绘制图表
+      // 绘制分数分布图表
       const ctx = document.getElementById('scoreDistributionChart').getContext('2d');
       const maxScore = Math.max(...scores);
       const binCount = 10;
@@ -283,6 +284,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
     playPauseBtn.addEventListener('click', togglePlay);
     
 
+    // 触发动画效果的辅助函数
     function triggerAnimationOnce(el, className) {
       if (!el || !className) return;
 
@@ -432,7 +434,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
 
 
     
-    // 更新显示信息
+    // 更新时间轴信息显示
     function updateTimelineInfo() {
         const data = timelineData[currentIndex];
         currentTimeSpan.textContent = `当前提交: #${data.submissionId}`;
@@ -453,7 +455,7 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
         updateTimelineInfo();
     });
     
-    // 按钮事件
+    // 上/下一个快照按钮事件
     prevBtn.addEventListener('click', function() {
         if (currentIndex > 0) {
             currentIndex--;
@@ -481,22 +483,22 @@ document.getElementById('timestamp').textContent = new Date().toLocaleString();
     });
   });
 
-  // 全屏功能实现
-  const toggleFullscreenBtn = document.getElementById('toggleFullscreen');
-  const exitFullscreenBtn = document.getElementById('exitFullscreen');
-  
-  toggleFullscreenBtn.addEventListener('click', function() {
-    document.body.classList.add('fullscreen-mode');
-    window.scrollTo(0, 0);
-  });
-  
-  exitFullscreenBtn.addEventListener('click', function() {
+// 全屏功能实现
+const toggleFullscreenBtn = document.getElementById('toggleFullscreen');
+const exitFullscreenBtn = document.getElementById('exitFullscreen');
+
+toggleFullscreenBtn.addEventListener('click', function() {
+  document.body.classList.add('fullscreen-mode');
+  window.scrollTo(0, 0);
+});
+
+exitFullscreenBtn.addEventListener('click', function() {
+  document.body.classList.remove('fullscreen-mode');
+});
+
+// ESC键退出全屏
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape' && document.body.classList.contains('fullscreen-mode')) {
     document.body.classList.remove('fullscreen-mode');
-  });
-  
-  // ESC键退出全屏
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && document.body.classList.contains('fullscreen-mode')) {
-      document.body.classList.remove('fullscreen-mode');
-    }
-  });
+  }
+});

--- a/app/static/js/standing.js
+++ b/app/static/js/standing.js
@@ -1,4 +1,5 @@
-document.getElementById('timestamp').textContent = new Date().toLocaleString();
+// 修复 standing.js 首行报错（页面无 timestamp 元素）
+// document.getElementById('timestamp').textContent = new Date().toLocaleString();
 
 // DOMContentLoaded事件，初始化所有交互逻辑
 document.addEventListener('DOMContentLoaded', function() {

--- a/app/static/js/tasklist.js
+++ b/app/static/js/tasklist.js
@@ -268,10 +268,28 @@ function resumeTask(taskId, taskType) {
     }
 }
 
+// 提交任务后自动跳转到流式榜单页面
+function submitTaskForm(form) {
+  fetch(form.action, {
+    method: form.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(Object.fromEntries(new FormData(form)))
+  })
+  .then(res => res.json())
+  .then(data => {
+    if (data.success && data.task_id) {
+      window.location.href = `/standing/stream_view/${data.task_id}`;
+    } else {
+      alert(data.message || '任务创建失败');
+    }
+  });
+  return false;
+}
+
 // 查看任务
 function viewTask(taskId, taskType) {
     if (taskType === 'standing') {
-        window.location.href = `/standing/data/${taskId}`;
+        window.location.href = `/standing/stream_view/${taskId}`;
     } else {
         // 原有逻辑
         const form = document.createElement('form');

--- a/app/static/js/tasklist.js
+++ b/app/static/js/tasklist.js
@@ -133,7 +133,7 @@ function renderTaskList(tasks, totalTime) {
         // 任务类型标记
         let typeBadge = task.task_type === 'standing' ? '<span class="badge bg-info">榜单</span>' : '<span class="badge bg-secondary">普通</span>';
         // 剩余时间小于总时间则显示剩余时间，否则显示"等待"
-        const remainingDisplay = task.remaining<totalTime?`${task.remaining}s`:`等待`;
+        const remainingDisplay = task.remaining<totalTime?`${Math.round(task.remaining,2)}s`:`等待`;
         const remainingPercent = task.remaining > 0 ? 
             Math.min(100, (task.remaining / totalTime) * 100) : 0.00;
         let actionButton = '';
@@ -155,14 +155,15 @@ function renderTaskList(tasks, totalTime) {
                 </span>
             </td>
             <td>${task.start} - ${task.end}</td>
-            <td>
-                ${task.progress}%
-                <div class="progress-container">
-                    <div class="progress-bar" style="width: ${task.progress}%"></div>
+            <td class="task-progress-cell">
+                <div class="progress-align-wrap">
+                  <span class="progress-percent">${task.progress}%</span>
+                  <div class="progress-container">
+                      <div class="progress-bar" style="width: ${task.progress}%"></div>
+                  </div>
                 </div>
             </td>
-            <td>
-                ${remainingDisplay}
+            <td class="task-remaining-cell"><span>${remainingDisplay}</span>
                 <div class="progress-container">
                     <div class="progress-bar" style="width: ${remainingPercent}%"></div>
                 </div>

--- a/app/static/js/tasklist.js
+++ b/app/static/js/tasklist.js
@@ -85,7 +85,7 @@ function fetchTasks() {
         // 进度百分比兼容
         normalTasks.forEach(t => { if(typeof t.progress !== 'number') t.progress = 0; });
         standingTasks.forEach(t => {
-            t.progress = t.end > t.start ? Math.round((t.current-t.start)/(t.end-t.start)*100) : 100;
+            t.progress = t.end > t.start ? Math.round((t.current-t.start)/(t.end-t.start+1)*100) : 100;
         });
         renderTaskList([...normalTasks, ...standingTasks], normal.tottime || 0);
     }).catch(error => {

--- a/app/static/js/tasklist.js
+++ b/app/static/js/tasklist.js
@@ -1,4 +1,4 @@
-// DOM元素
+// 任务列表相关DOM元素
 const taskListBody = document.getElementById('task-list-body');
 const refreshBtn = document.getElementById('refresh-btn');
 const autoRefreshCheckbox = document.getElementById('auto-refresh');
@@ -20,7 +20,7 @@ let searchQuery = '';
 let autoRefreshInterval;
 let countdownInterval;
 
-// 初始化页面
+// 页面初始化，加载任务和事件监听
 document.addEventListener('DOMContentLoaded', function() {
     fetchTasks();
     setupEventListeners();
@@ -29,7 +29,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // 设置事件监听器
 function setupEventListeners() {
+    // 刷新按钮点击事件
     refreshBtn.addEventListener('click', fetchTasks);
+    // 自动刷新开关事件
     autoRefreshCheckbox.addEventListener('change', function() {
         if (this.checked) {
             startAutoRefresh();
@@ -37,6 +39,7 @@ function setupEventListeners() {
             stopAutoRefresh();
         }
     });
+    // 过滤按钮点击事件
     filterButtons.forEach(button => {
         button.addEventListener('click', function() {
             filterButtons.forEach(btn => btn.classList.remove('active'));
@@ -45,16 +48,18 @@ function setupEventListeners() {
             fetchTasks();
         });
     });
+    // 搜索输入框输入事件
     searchInput.addEventListener('input', function() {
         searchQuery = this.value.toLowerCase();
         fetchTasks();
     });
 }
 
-// 开始自动刷新
+// 启动自动刷新
 function startAutoRefresh() {
     if (autoRefreshInterval) clearInterval(autoRefreshInterval);
     fetchTasks();
+    // 每3秒自动刷新一次任务列表
     autoRefreshInterval = setInterval(() => {
         fetchTasks();
     }, 3000);
@@ -84,9 +89,11 @@ function fetchTasks() {
 // 渲染任务列表
 function renderTaskList(tasks, totalTime) {
     let filteredTasks = tasks.filter(task => {
+        // 根据当前过滤器过滤任务
         if (currentFilter !== 'all' && task.status !== currentFilter) {
             return false;
         }
+        // 根据搜索查询过滤任务
         if (searchQuery && 
             !(String(task.contest_id)).toLowerCase().includes(searchQuery) && 
             !(`${task.start}-${task.end}`.includes(searchQuery))) {
@@ -94,6 +101,7 @@ function renderTaskList(tasks, totalTime) {
         }
         return true;
     });
+    // 更新统计信息
     updateStats(tasks);
     taskListBody.innerHTML = '';
     if (filteredTasks.length === 0) {
@@ -101,9 +109,11 @@ function renderTaskList(tasks, totalTime) {
         return;
     }
     noTasksMessage.style.display = 'none';
+    // 渲染每个任务的表格行
     filteredTasks.forEach(task => {
         const row = document.createElement('tr');
         let statusText;
+        // 根据任务状态设置状态文本
         switch(task.status) {
             case 'running': statusText = '运行中'; break;
             case 'completed': statusText = '已完成'; break;
@@ -112,10 +122,12 @@ function renderTaskList(tasks, totalTime) {
             case 'paused': statusText = '已暂停'; break;
             default: statusText = task.status;
         }
+        // 剩余时间小于总时间则显示剩余时间，否则显示"等待"
         const remainingDisplay = task.remaining<tottime?`${task.remaining}s`:`等待`;
         const remainingPercent = task.remaining > 0 ? 
             Math.min(100, (task.remaining / totalTime) * 100) : 0;
         let actionButton = '';
+        // 根据任务状态设置操作按钮
         if (task.status === 'paused') {
             actionButton = `<button class="action-btn resume" data-id="${task.id}">
                 <i class="fas fa-play"></i> 继续
@@ -157,15 +169,18 @@ function renderTaskList(tasks, totalTime) {
         `;
         taskListBody.appendChild(row);
     });
+    // 为暂停和继续按钮设置点击事件
     document.querySelectorAll('.pause').forEach(btn => {
         btn.addEventListener('click', () => pauseTask(btn.dataset.id));
     });
     document.querySelectorAll('.resume').forEach(btn => {
         btn.addEventListener('click', () => resumeTask(btn.dataset.id));
     });
+    // 启动倒计时
     startCountdown(totalTime);
 }
 
+// 更新统计信息
 function updateStats(tasks) {
     const stats = {
         running: 0,
@@ -173,6 +188,7 @@ function updateStats(tasks) {
         completed: 0,
         error: 0
     };
+    // 统计各个状态的任务数量
     tasks.forEach(task => {
         if (stats.hasOwnProperty(task.status)) {
             stats[task.status]++;
@@ -184,6 +200,7 @@ function updateStats(tasks) {
     errorCount.textContent = stats.error;
 }
 
+// 暂停任务
 function pauseTask(taskId) {
     fetch(`/api/task/${taskId}/pause`, {
         method: 'POST'
@@ -203,6 +220,7 @@ function pauseTask(taskId) {
     });
 }
 
+// 恢复任务
 function resumeTask(taskId) {
     fetch(`/api/task/${taskId}/resume`, {
         method: 'POST'
@@ -222,6 +240,7 @@ function resumeTask(taskId) {
     });
 }
 
+// 显示通知
 function showNotification(message, type) {
     notificationText.textContent = message;
     notification.className = `notification ${type} show`;
@@ -238,6 +257,7 @@ function showNotification(message, type) {
     }, 3000);
 }
 
+// 启动倒计时，实时更新剩余时间
 function startCountdown(totalTime) {
     if (countdownInterval) clearInterval(countdownInterval);
     countdownInterval = setInterval(() => {

--- a/app/static/js/tasklist.js
+++ b/app/static/js/tasklist.js
@@ -81,7 +81,7 @@ function fetchTasks() {
     ]).then(([normal, standing]) => {
         // 标记任务类型
         const normalTasks = (normal.tasks || []).map(t => ({...t, task_type: 'normal', remaining: t.remaining ?? 0}));
-        const standingTasks = (standing.tasks || []).map(t => ({...t, task_type: 'standing', remaining: 0}));
+        const standingTasks = (standing.tasks || []).map(t => ({...t, task_type: 'standing', remaining: t.remaining ?? 0}));
         // 进度百分比兼容
         normalTasks.forEach(t => { if(typeof t.progress !== 'number') t.progress = 0; });
         standingTasks.forEach(t => {
@@ -135,7 +135,7 @@ function renderTaskList(tasks, totalTime) {
         // 剩余时间小于总时间则显示剩余时间，否则显示"等待"
         const remainingDisplay = task.remaining<totalTime?`${task.remaining}s`:`等待`;
         const remainingPercent = task.remaining > 0 ? 
-            Math.min(100, (task.remaining / totalTime) * 100) : 0;
+            Math.min(100, (task.remaining / totalTime) * 100) : 0.00;
         let actionButton = '';
         // 根据任务状态设置操作按钮
         if (task.status === 'paused') {

--- a/app/static/js/waiting.js
+++ b/app/static/js/waiting.js
@@ -1,6 +1,7 @@
 // waiting.js
 // 提取自 waiting.html 的所有 JS 逻辑
 
+// 轮询后端进度并更新进度条、状态等
 function updateProgress() {
     fetch('/progress')
         .then(response => response.json())
@@ -10,6 +11,7 @@ function updateProgress() {
 
             document.getElementById('progress-fill').style.width = progress + '%';
 
+            // 处理不同状态下的按钮显示和文本内容
             if (status !== 'running') {
                 document.getElementById('cancel-btn').style.display = 'none';
                 document.getElementById('home-btn').style.display = '';
@@ -50,10 +52,12 @@ function updateProgress() {
         });
 }
 
+// 取消按钮点击，弹出确认框
 document.getElementById('cancel-btn').addEventListener('click', function () {
     document.getElementById('confirm-modal').style.display = 'flex';
 });
 
+// 确认取消，向后端发送取消请求
 document.getElementById('confirm-yes').addEventListener('click', function () {
     fetch('/cancel', {
         method: 'POST',
@@ -70,14 +74,17 @@ document.getElementById('confirm-yes').addEventListener('click', function () {
     document.getElementById('confirm-modal').style.display = 'none';
 });
 
+// 取消确认弹窗的否定按钮
 document.getElementById('confirm-no').addEventListener('click', function () {
     document.getElementById('confirm-modal').style.display = 'none';
 });
 
+// 返回首页按钮
 document.getElementById('home-btn').addEventListener('click', function () {
     window.location.href = '/';
 });
 
+// 暂停按钮，向后端发送暂停请求
 document.getElementById('pause-btn').addEventListener('click', function () {
     fetch('/pause', {
         method: 'POST',
@@ -94,8 +101,7 @@ document.getElementById('pause-btn').addEventListener('click', function () {
         }
     });
 });
-// 恢复按钮事件
-
+// 恢复按钮，向后端发送恢复请求
 document.getElementById('resume-btn').addEventListener('click', function() {
     fetch('/resume', {
         method: 'POST',
@@ -112,5 +118,7 @@ document.getElementById('resume-btn').addEventListener('click', function() {
         }
     });
 });
+// 定时轮询进度
 setInterval(updateProgress, 1000);
+// 页面初始加载时立即获取一次进度
 updateProgress(); // 初始加载

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -25,26 +25,48 @@
             box-shadow: 0 4px 16px rgba(23,162,184,0.18);
             transform: translateY(-2px) scale(1.04);
         }
+        .lang-switch-bar {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 8px;
+            margin: 10px 0 0 0;
+            padding-right: 0;
+        }
+        .lang-btn {
+            background: #f8f9fa;
+            color: #138496;
+            border: 1px solid #17a2b8;
+            border-radius: 18px;
+            padding: 4px 18px;
+            font-size: 0.95rem;
+            font-weight: 500;
+            margin: 0;
+            transition: background 0.2s, color 0.2s;
+        }
+        .lang-btn.active, .lang-btn:hover {
+            background: #17a2b8;
+            color: #fff;
+        }
     </style>
 </head>
 <body>
     <div class="container">
-        <h1>PLEASE INPUT THREE INTEGERS:</h1>
+        <h1 id="main-title">PLEASE INPUT THREE INTEGERS:</h1>
         <form method="POST">
-            <label for="start_id">FROM:</label>
+            <label for="start_id" id="label-from">FROM:</label>
             <input type="number" name="start_id" id="start_id" required>
 
-            <label for="end_id">TO:</label>
+            <label for="end_id" id="label-to">TO:</label>
             <input type="number" name="end_id" id="end_id" required>
 
-            <label for="cid">CONTEST ID:</label>
+            <label for="cid" id="label-cid">CONTEST ID:</label>
             <input type="number" name="cid" id="cid" required>
 
-            <input type="submit" value="SUBMIT">
+            <input type="submit" id="submit-btn" value="SUBMIT">
         </form>
-        
         <div style="text-align: center; margin-top: 20px;">
-            <a href="/tasklist" style="color: #007BFF; text-decoration: none;">
+            <a href="/tasklist" style="color: #007BFF; text-decoration: none;" id="show-task-link">
             Show task list
             </a>
         </div>
@@ -55,12 +77,12 @@
         <div id="standingTaskModal" class="modal" style="display:none;position:fixed;z-index:1000;left:0;top:0;width:100vw;height:100vh;background:rgba(0,0,0,0.4);align-items:center;justify-content:center;">
             <div style="background:#fff;padding:30px 40px;border-radius:8px;min-width:320px;max-width:90vw;position:relative;">
                 <button id="closeStandingTaskModal" style="position:absolute;right:10px;top:10px;font-size:20px;background:none;border:none;">&times;</button>
-                <h2 style="margin-bottom:20px;">New auto standing</h2>
+                <h2 id="modal-title" style="margin-bottom:20px;">New auto standing</h2>
                 <form id="createStandingTaskForm">
-                    <label>contest id: <input type="number" name="contest_id" required></label><br><br>
-                    <label>start id: <input type="number" name="start_id" required></label><br><br>
-                    <label>end id: <input type="number" name="end_id" required></label><br><br>
-                    <button type="submit" class="bottom-btn">Submit</button>
+                    <label id="label-modal-cid">contest id: <input type="number" name="contest_id" required></label><br><br>
+                    <label id="label-modal-start">start id: <input type="number" name="start_id" required></label><br><br>
+                    <label id="label-modal-end">end id: <input type="number" name="end_id" required></label><br><br>
+                    <button type="submit" class="bottom-btn" id="modal-submit-btn">Submit</button>
                 </form>
                 <div id="standingTaskMsg" style="margin-top:10px;color:#28a745;"></div>
             </div>
@@ -97,7 +119,68 @@
                 document.getElementById('standingTaskMsg').textContent = '创建失败';
             });
         };
+
+        // 语言映射
+        const langMap = {
+            en: {
+                title: 'DMYBOT',
+                inputTitle: 'PLEASE INPUT THREE INTEGERS:',
+                from: 'FROM:',
+                to: 'TO:',
+                cid: 'CONTEST ID:',
+                submit: 'SUBMIT',
+                showTask: 'Show task list',
+                createStanding: 'Create auto standing',
+                modalTitle: 'New auto standing',
+                contestId: 'contest id:',
+                startId: 'start id:',
+                endId: 'end id:',
+                submitBtn: 'Submit'
+            },
+            zh: {
+                title: 'DMYBOT',
+                inputTitle: '请输入三个整数：',
+                from: '起始编号：',
+                to: '结束编号：',
+                cid: '比赛ID：',
+                submit: '提交',
+                showTask: '查看任务列表',
+                createStanding: '创建榜单任务',
+                modalTitle: '新建榜单任务',
+                contestId: '比赛ID：',
+                startId: '起始编号：',
+                endId: '结束编号：',
+                submitBtn: '提交'
+            }
+        };
+        let currentLang = 'en';
+        function setLang(lang) {
+            currentLang = lang;
+            document.title = langMap[lang].title;
+            document.getElementById('main-title').textContent = langMap[lang].inputTitle;
+            document.getElementById('label-from').textContent = langMap[lang].from;
+            document.getElementById('label-to').textContent = langMap[lang].to;
+            document.getElementById('label-cid').textContent = langMap[lang].cid;
+            document.getElementById('submit-btn').value = langMap[lang].submit;
+            document.getElementById('show-task-link').textContent = langMap[lang].showTask;
+            document.getElementById('openStandingTaskModal').textContent = langMap[lang].createStanding;
+            document.getElementById('modal-title').textContent = langMap[lang].modalTitle;
+            document.getElementById('label-modal-cid').innerHTML = langMap[lang].contestId + ' <input type="number" name="contest_id" required>';
+            document.getElementById('label-modal-start').innerHTML = langMap[lang].startId + ' <input type="number" name="start_id" required>';
+            document.getElementById('label-modal-end').innerHTML = langMap[lang].endId + ' <input type="number" name="end_id" required>';
+            document.getElementById('modal-submit-btn').textContent = langMap[lang].submitBtn;
+            // 语言按钮高亮
+            document.getElementById('lang-en').classList.toggle('active', lang==='en');
+            document.getElementById('lang-zh').classList.toggle('active', lang==='zh');
+        }
+        // 默认语言
+        setLang('zh');
         </script>
+    
+        <div class="lang-switch-bar">
+            <button onclick="setLang('en')" class="lang-btn" id="lang-en">English</button>
+            <button onclick="setLang('zh')" class="lang-btn" id="lang-zh">中文</button>
+        </div>
     </div>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -66,11 +66,11 @@
             })
             .then(res => res.json())
             .then(res => {
-                document.getElementById('standingTaskMsg').textContent = '创建成功！';
-                setTimeout(()=>{
-                    document.getElementById('standingTaskModal').style.display = 'none';
-                    document.getElementById('standingTaskMsg').textContent = '';
-                }, 1000);
+                if(res.success && res.task_id) {
+                    window.location.href = `/standing/stream_view/${res.task_id}`;
+                } else {
+                    document.getElementById('standingTaskMsg').textContent = res.message || '创建失败';
+                }
             })
             .catch(()=>{
                 document.getElementById('standingTaskMsg').textContent = '创建失败';

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,6 +5,27 @@
     <title>DMYBOT</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
+    <style>
+        .bottom-btn {
+            display: inline-block;
+            background: linear-gradient(90deg, #17a2b8 60%, #138496 100%);
+            color: #fff;
+            border: none;
+            border-radius: 25px;
+            padding: 12px 36px;
+            font-size: 1.1rem;
+            font-weight: 600;
+            box-shadow: 0 2px 8px rgba(23,162,184,0.12);
+            cursor: pointer;
+            transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
+            margin: 10px auto 0 auto;
+        }
+        .bottom-btn:hover {
+            background: linear-gradient(90deg, #138496 60%, #17a2b8 100%);
+            box-shadow: 0 4px 16px rgba(23,162,184,0.18);
+            transform: translateY(-2px) scale(1.04);
+        }
+    </style>
 </head>
 <body>
     <div class="container">
@@ -28,18 +49,18 @@
             </a>
         </div>
         <div style="text-align: center; margin-top: 20px;">
-            <button id="openStandingTaskModal" class="action-btn" style="background:#17a2b8;color:#fff;">创建榜单任务</button>
+            <button id="openStandingTaskModal" class="bottom-btn">Create auto standing</button>
         </div>
         <!-- 榜单任务创建弹窗 -->
         <div id="standingTaskModal" class="modal" style="display:none;position:fixed;z-index:1000;left:0;top:0;width:100vw;height:100vh;background:rgba(0,0,0,0.4);align-items:center;justify-content:center;">
             <div style="background:#fff;padding:30px 40px;border-radius:8px;min-width:320px;max-width:90vw;position:relative;">
                 <button id="closeStandingTaskModal" style="position:absolute;right:10px;top:10px;font-size:20px;background:none;border:none;">&times;</button>
-                <h2 style="margin-bottom:20px;">创建榜单任务</h2>
+                <h2 style="margin-bottom:20px;">New auto standing</h2>
                 <form id="createStandingTaskForm">
-                    <label>比赛编号: <input type="number" name="contest_id" required></label><br><br>
-                    <label>起始ID: <input type="number" name="start_id" required></label><br><br>
-                    <label>结束ID: <input type="number" name="end_id" required></label><br><br>
-                    <button type="submit" class="action-btn" style="background:#17a2b8;color:#fff;">提交</button>
+                    <label>contest id: <input type="number" name="contest_id" required></label><br><br>
+                    <label>start id: <input type="number" name="start_id" required></label><br><br>
+                    <label>end id: <input type="number" name="end_id" required></label><br><br>
+                    <button type="submit" class="bottom-btn">Submit</button>
                 </form>
                 <div id="standingTaskMsg" style="margin-top:10px;color:#28a745;"></div>
             </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -27,6 +27,56 @@
             Show task list
             </a>
         </div>
+        <div style="text-align: center; margin-top: 20px;">
+            <button id="openStandingTaskModal" class="action-btn" style="background:#17a2b8;color:#fff;">创建榜单任务</button>
+        </div>
+        <!-- 榜单任务创建弹窗 -->
+        <div id="standingTaskModal" class="modal" style="display:none;position:fixed;z-index:1000;left:0;top:0;width:100vw;height:100vh;background:rgba(0,0,0,0.4);align-items:center;justify-content:center;">
+            <div style="background:#fff;padding:30px 40px;border-radius:8px;min-width:320px;max-width:90vw;position:relative;">
+                <button id="closeStandingTaskModal" style="position:absolute;right:10px;top:10px;font-size:20px;background:none;border:none;">&times;</button>
+                <h2 style="margin-bottom:20px;">创建榜单任务</h2>
+                <form id="createStandingTaskForm">
+                    <label>比赛编号: <input type="number" name="contest_id" required></label><br><br>
+                    <label>起始ID: <input type="number" name="start_id" required></label><br><br>
+                    <label>结束ID: <input type="number" name="end_id" required></label><br><br>
+                    <button type="submit" class="action-btn" style="background:#17a2b8;color:#fff;">提交</button>
+                </form>
+                <div id="standingTaskMsg" style="margin-top:10px;color:#28a745;"></div>
+            </div>
+        </div>
+        <script>
+        document.getElementById('openStandingTaskModal').onclick = function() {
+            document.getElementById('standingTaskModal').style.display = 'flex';
+        };
+        document.getElementById('closeStandingTaskModal').onclick = function() {
+            document.getElementById('standingTaskModal').style.display = 'none';
+        };
+        document.getElementById('createStandingTaskForm').onsubmit = function(e) {
+            e.preventDefault();
+            const form = e.target;
+            const data = {
+                contest_id: Number(form.contest_id.value),
+                start_id: Number(form.start_id.value),
+                end_id: Number(form.end_id.value)
+            };
+            fetch('/standing/create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            })
+            .then(res => res.json())
+            .then(res => {
+                document.getElementById('standingTaskMsg').textContent = '创建成功！';
+                setTimeout(()=>{
+                    document.getElementById('standingTaskModal').style.display = 'none';
+                    document.getElementById('standingTaskMsg').textContent = '';
+                }, 1000);
+            })
+            .catch(()=>{
+                document.getElementById('standingTaskMsg').textContent = '创建失败';
+            });
+        };
+        </script>
     </div>
 </body>
 </html>

--- a/app/templates/new_standing.html
+++ b/app/templates/new_standing.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>成绩排名表（流式）</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/standing.css') }}" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
+<script src="https://unpkg.com/tablesort/dist/sorts/tablesort.number.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chroma-js@2.4.2/chroma.min.js"></script>
+</head>
+<body>
+<div class="main-container">
+  <div class="content-wrapper">
+    <div class="decor-element decor-circle"></div>
+    <div class="decor-element decor-blob"></div>
+    <div class="header">
+      <div class="header d-flex justify-content-between align-items-center my-4">
+        <h1 class="mx-auto">成绩排名表（流式）</h1>
+        <form action="/retry" method="post">
+          <input type="hidden" name="start_id" value="{{startid}}">
+          <input type="hidden" name="end_id" value="{{endid}}">
+          <input type="hidden" name="cid" value="{{cid}}">
+        </form>
+      </div>
+    </div>
+    <div class="card">
+      <div class="controls">
+        <div class="search-container">
+          <input type="text" id="searchInput" placeholder="搜索用户名...">
+        </div>
+        <div class="fullscreen-controls">
+          <button id="toggleFullscreen" class="fullscreen-btn" title="全屏显示">
+            ↗
+          </button>
+          <button id="exitFullscreen" class="fullscreen-btn" title="退出全屏">
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="card timeline-container">
+      <div class="timeline-controls">
+        <button id="prevSnapshot" class="timeline-btn" title="上一个时刻">◀</button>
+        <div class="timeline-slider-container" style="position:relative;">
+          <input type="range" id="timelineSlider" class="timeline-slider" min="0" max="100" value="100">
+          <div class="timeline-marks">
+            <span id="timelineStart" style="position:absolute;left:0;top:18px;font-size:12px;cursor:pointer;color:#007bff;">起点</span>
+            <span id="timelineEnd" style="position:absolute;right:0;top:18px;font-size:12px;cursor:pointer;color:#007bff;">终点</span>
+            <span id="timelineCurrent" style="position:absolute;left:50%;top:18px;font-size:12px;transform:translateX(-50%);color:#333;">当前提交: --</span>
+          </div>
+        </div>
+        <button id="nextSnapshot" class="timeline-btn" title="下一个时刻">▶</button>
+      </div>
+    </div>
+    <div class="card table-card">
+      <div id="stream-table-container">
+        <!-- 流式表格内容将由 JS 动态填充 -->
+      </div>
+    </div>
+    <div class="card chart-card">
+      <canvas id="scoreChart"></canvas>
+    </div>
+  </div>
+</div>
+<script src="{{ url_for('static', filename='js/standing.js') }}"></script>
+<script src="{{ url_for('static', filename='js/standing-anim.js') }}"></script>
+<script>
+// 记录上一次分数快照和排名快照
+let lastScoreSnapshot = {};
+let lastRankSnapshot = [];
+function getCurrentRankSnapshot() {
+  return Array.from(document.querySelectorAll('#rank-table tbody tr')).map(row => row.querySelector('.username-cell').textContent);
+}
+// 包装表格渲染函数，添加分数和排名动画
+const origRenderTableBySnapshot = window.renderTableBySnapshot;
+window.renderTableBySnapshot = function(idx) {
+  origRenderTableBySnapshot(idx);
+  // 分数动画（只对变化的）
+  setTimeout(() => {
+    let curScoreSnapshot = {};
+    document.querySelectorAll('#rank-table tbody tr').forEach(row => {
+      const user = row.querySelector('.username-cell').textContent;
+      curScoreSnapshot[user] = [];
+      row.querySelectorAll('.score-cell .score-text').forEach((span, idx) => {
+        curScoreSnapshot[user][idx] = span.textContent;
+      });
+    });
+    document.querySelectorAll('#rank-table tbody tr').forEach(row => {
+      const user = row.querySelector('.username-cell').textContent;
+      row.querySelectorAll('.score-cell .score-text').forEach((span, idx) => {
+        if (!lastScoreSnapshot[user] || lastScoreSnapshot[user][idx] !== span.textContent) {
+          span.classList.remove('score-change');
+          void span.offsetWidth;
+          span.classList.add('score-change');
+        }
+      });
+    });
+    lastScoreSnapshot = curScoreSnapshot;
+    // 整行排名动画
+    if (window.standingAnim && window.standingAnim.triggerAnimationOnce) {
+      const oldOrder = lastRankSnapshot.length ? lastRankSnapshot : getCurrentRankSnapshot();
+      const rows = Array.from(document.querySelectorAll('#rank-table tbody tr'));
+      const oldPositions = new Map();
+      oldOrder.forEach((username, i) => oldPositions.set(username, i));
+      rows.forEach((row, newIdx) => {
+        const username = row.querySelector('.username-cell').textContent;
+        const oldIdx = oldPositions.get(username);
+        if (oldIdx !== undefined && oldIdx !== newIdx) {
+          const dist = (oldIdx - newIdx) * row.offsetHeight;
+          row.style.setProperty('--move-distance', `${dist}px`);
+          const className = oldIdx > newIdx ? 'rank-up' : 'rank-down';
+          window.standingAnim.triggerAnimationOnce(row, className);
+        }
+      });
+      lastRankSnapshot = getCurrentRankSnapshot();
+    }
+  }, 30);
+};
+// 修正表头和分数颜色
+function fixTableHeaderAndColor() {
+  // 修正表头（如有需要可自定义）
+  const table = document.getElementById('rank-table');
+  if (table) {
+    // 例如：将表头内容全部转为中文（如有需要可自定义映射）
+    const ths = table.querySelectorAll('thead th');
+    ths.forEach((th, idx) => {
+      // 这里可以自定义表头映射
+      if (th.textContent === '用户名') th.textContent = '用户名';
+      if (th.textContent.match(/^\d+$/)) th.textContent = '题目' + th.textContent;
+      if (th.textContent === '总分') th.textContent = '总分';
+    });
+  }
+}
+// 监听 SSE 数据渲染后修正
+eventSource.onmessage = function(e) {
+  if (typeof origEventSource === 'function') origEventSource.call(this, e);
+  setTimeout(fixTableHeaderAndColor, 100); // 等待表格渲染后修正
+};
+// 页面初次加载也修正一次
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', fixTableHeaderAndColor);
+} else {
+  fixTableHeaderAndColor();
+}
+</script>
+<script>
+let timelineData = [];
+let tableHeader = [];
+let users = [];
+let problems = [];
+let problemMap = {};
+
+function renderTableBySnapshot(idx) {
+  if (!timelineData.length || !users.length || !tableHeader.length) return;
+  // 1. 计算当前快照所有用户每题分数
+  const snapshot = timelineData[idx];
+  // 构建分数字典：user -> problem -> score
+  const userScores = {};
+  users.forEach(u => { userScores[u] = {}; problems.forEach(p => { userScores[u][p] = 0; }); });
+  // 累加到当前快照
+  for (let i = 0; i <= idx; ++i) {
+    const snap = timelineData[i];
+    if (userScores[snap.username] && userScores[snap.username][snap.problemId] !== undefined) {
+      userScores[snap.username][snap.problemId] = snap.score;
+    }
+  }
+  // 2. 计算总分并排序
+  const userTotal = users.map(u => {
+    let total = 0;
+    problems.forEach(p => { total += userScores[u][p]; });
+    return { user: u, total, scores: problems.map(p => userScores[u][p]) };
+  });
+  userTotal.sort((a, b) => b.total - a.total);
+  // 3. 渲染表格（修正表头和列顺序）
+  let html = '<table id="rank-table" class="table table-hover"><thead><tr>';
+  html += '<th>排名</th><th>用户名</th>';
+  problems.forEach(p => {
+    if (problemMap && problemMap[p]) {
+      html += `<th>${p}：${problemMap[p]}</th>`;
+    } else {
+      html += `<th>${p}</th>`;
+    }
+  });
+  html += '<th>总分</th></tr></thead><tbody>';
+  userTotal.forEach((row, i) => {
+    html += `<tr><td class="rank-cell">${i+1}</td><td class="username-cell">${row.user}</td>`;
+    row.scores.forEach((s, j) => {
+      // 拼接提交历史
+      let historyHtml = '';
+      if (window.submission_history && window.submission_history[row.user] && window.submission_history[row.user][problems[j]]) {
+        const historyArr = window.submission_history[row.user][problems[j]];
+        if (historyArr.length > 0) {
+          historyHtml = '<div class="submission-history">' + historyArr.map(item =>
+            `<div class=\"history-item\"><a href=\"http://oj.daimayuan.top/submission/${item[0]}\" class=\"submission-link\" target=\"_blank\">#${item[0]}</a><span class=\"score\">${item[1]}</span></div>`
+          ).join('') + '</div>';
+        }
+      }
+      html += `<td class=\"score-cell\"><span class=\"score-text\">${s}</span>${historyHtml}</td>`;
+    });
+    html += `<td class=\"score-cell\"><span class=\"score-text\">${row.total}</span></td></tr>`;
+  });
+  html += '</tbody></table>';
+  document.getElementById('stream-table-container').innerHTML = html;
+  colorScoreCellsForNewStanding();
+}
+
+function updateTimelineBySlider(val) {
+  if (!timelineData.length) return;
+  const idx = Math.round((val / 100) * (timelineData.length - 1));
+  const data = timelineData[idx];
+  // 动态显示当前提交编号
+  const cur = document.getElementById('timelineCurrent');
+  if (cur && data && data.submissionId !== undefined) {
+    cur.textContent = '当前提交: #' + data.submissionId;
+  } else if (cur) {
+    cur.textContent = '当前提交: --';
+  }
+  renderTableBySnapshot(idx);
+}
+
+// timeline 滑块和左右按钮事件绑定
+function bindTimelineEvents() {
+  const slider = document.getElementById('timelineSlider');
+  const prevBtn = document.getElementById('prevSnapshot');
+  const nextBtn = document.getElementById('nextSnapshot');
+  if (!slider || !timelineData.length) return;
+  let currentIdx = timelineData.length - 1;
+  slider.addEventListener('input', function() {
+    currentIdx = Math.round((this.value / 100) * (timelineData.length - 1));
+    updateTimelineBySlider(this.value);
+  });
+  prevBtn && prevBtn.addEventListener('click', function() {
+    if (currentIdx > 0) {
+      currentIdx--;
+      slider.value = (currentIdx / (timelineData.length - 1)) * 100;
+      updateTimelineBySlider(slider.value);
+    }
+  });
+  nextBtn && nextBtn.addEventListener('click', function() {
+    if (currentIdx < timelineData.length - 1) {
+      currentIdx++;
+      slider.value = (currentIdx / (timelineData.length - 1)) * 100;
+      updateTimelineBySlider(slider.value);
+    }
+  });
+}
+
+window.eventSource = new EventSource(`/standing/stream/{{ task_id }}`);
+window.eventSource.onmessage = function(e) {
+  const data = JSON.parse(e.data);
+  timelineData = data.timeline_data || [];
+  tableHeader = data.table_header || [];
+  users = data.users || [];
+  problems = data.problems || [];
+  problemMap = data.problem_map || {};
+  window.submission_history = data.submission_history || {};
+  if (data.error) {
+    document.getElementById('stream-table-container').innerHTML = `<div>${data.error}</div>`;
+    return;
+  }
+  // 每次收到数据都刷新表格并触发动画
+  if (timelineData.length) {
+    document.getElementById('timelineSlider').value = 100;
+    // 先渲染表格
+    updateTimelineBySlider(100);
+    // 触发动画：对所有分数单元格添加 score-change 动画类
+    setTimeout(() => {
+      document.querySelectorAll('#rank-table .score-cell .score-text').forEach(span => {
+        span.classList.remove('score-change');
+        // 强制重绘
+        void span.offsetWidth;
+        span.classList.add('score-change');
+      });
+      // 新增：对所有排名单元格触发排名动画
+      if (window.standingAnim && window.standingAnim.applyRankAnimation) {
+        const rows = Array.from(document.querySelectorAll('#rank-table tbody tr'));
+        const oldPositions = new Map();
+        rows.forEach((r, i) => oldPositions.set(r.querySelector('.username-cell').textContent, i));
+        // 以当前顺序为 oldPositions，下一次渲染后再触发动画
+        setTimeout(() => {
+          const newRows = Array.from(document.querySelectorAll('#rank-table tbody tr'));
+          window.standingAnim.applyRankAnimation(newRows, oldPositions, newRows);
+        }, 10);
+      }
+    }, 50);
+    bindTimelineEvents();
+  }
+};
+window.eventSource.onerror = function() {
+  window.eventSource.close();
+};
+// 独立提取分数颜色渲染函数，供本页面表格渲染后调用，不影响 standing.html
+function colorScoreCellsForNewStanding() {
+  if (typeof chroma === 'undefined') return;
+  const colorScale = chroma.scale(['#e74c3c', '#f39c12', '#27ae60']).domain([0, 50, 100]);
+  document.querySelectorAll('#rank-table tbody td.score-cell').forEach(cell => {
+    let scoreSpan = cell.querySelector('.score-text');
+    if (!scoreSpan) return;
+    const score = parseFloat(scoreSpan.textContent);
+    const isTotalScore = cell.cellIndex === cell.parentElement.cells.length - 1;
+    const maxScore = isTotalScore ? 300 : 100;
+    if (score < 0) {
+      scoreSpan.style.color = '#95a5a5';
+    } else {
+      let percent = Math.max(0, Math.min(1, score / maxScore));
+      scoreSpan.style.color = colorScale(percent * 100).hex();
+      scoreSpan.style.background = '';
+      scoreSpan.style.backgroundClip = '';
+      scoreSpan.style.webkitBackgroundClip = '';
+    }
+  });
+}
+// 在 renderTableBySnapshot 渲染后调用
+renderTableBySnapshot = function(idx) {
+  origRenderTableBySnapshot(idx);
+  colorScoreCellsForNewStanding();
+};
+document.getElementById('timelineSlider').addEventListener('input', function() {
+  updateTimelineBySlider(this.value);
+});
+</script>
+<style>
+@keyframes scoreChange {
+  0% { background-color: transparent; }
+  10%   { transform: scale(1.2); background-color: transparent; }
+  100% { background-color: transparent; }
+}
+.score-change {
+  display: inline-block;
+  animation: scoreChange 0.45s ease-out;
+}
+</style>
+</body>
+</html>

--- a/app/templates/new_standing.html
+++ b/app/templates/new_standing.html
@@ -1,88 +1,142 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>成绩排名表（流式）</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link href="{{ url_for('static', filename='css/standing.css') }}" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
-<script src="https://unpkg.com/tablesort/dist/sorts/tablesort.number.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chroma-js@2.4.2/chroma.min.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>流式榜单</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/standing.css') }}" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chroma-js@2.4.2/chroma.min.js"></script>
+  <script src="{{ url_for('static', filename='js/standing-anim.js') }}"></script>
+  <style>
+    @keyframes scoreChange { 0% { background-color: transparent; } 10% { transform: scale(1.2); background-color: transparent; } 100% { background-color: transparent; } }
+    .score-change { display: inline-block; animation: scoreChange 0.45s ease-out; }
+    /* 按钮样式与 standing.css 风格一致 */
+.standing-btn, #pause-btn {
+  display: inline-block;
+  padding: 6px 18px;
+  margin: 0 4px;
+  background: #fff;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  color: #333;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+  text-decoration: none;
+}
+.standing-btn:hover, #pause-btn:hover {
+  background: #f0f0f0;
+  color: #1976d2;
+  border-color: #1976d2;
+}
+  </style>
 </head>
 <body>
-<div class="main-container">
-  <div class="content-wrapper">
-    <div class="decor-element decor-circle"></div>
-    <div class="decor-element decor-blob"></div>
-    <div class="header">
-      <div class="header d-flex justify-content-between align-items-center my-4">
-        <h1 class="mx-auto">成绩排名表（流式）</h1>
-        <form action="/retry" method="post">
-          <input type="hidden" name="start_id" value="{{startid}}">
-          <input type="hidden" name="end_id" value="{{endid}}">
-          <input type="hidden" name="cid" value="{{cid}}">
-        </form>
-      </div>
-    </div>
-    <div class="card">
-      <div class="controls">
-        <div class="search-container">
-          <input type="text" id="searchInput" placeholder="搜索用户名...">
-        </div>
-        <div class="fullscreen-controls">
-          <button id="toggleFullscreen" class="fullscreen-btn" title="全屏显示">
-            ↗
-          </button>
-          <button id="exitFullscreen" class="fullscreen-btn" title="退出全屏">
-            ✕
-          </button>
-        </div>
-      </div>
-    </div>
-    <div class="card timeline-container">
-      <div class="timeline-controls">
-        <button id="prevSnapshot" class="timeline-btn" title="上一个时刻">◀</button>
-        <div class="timeline-slider-container" style="position:relative;">
-          <input type="range" id="timelineSlider" class="timeline-slider" min="0" max="100" value="100">
-          <div class="timeline-marks">
-            <span id="timelineStart" style="position:absolute;left:0;top:18px;font-size:12px;cursor:pointer;color:#007bff;">起点</span>
-            <span id="timelineEnd" style="position:absolute;right:0;top:18px;font-size:12px;cursor:pointer;color:#007bff;">终点</span>
-            <span id="timelineCurrent" style="position:absolute;left:50%;top:18px;font-size:12px;transform:translateX(-50%);color:#333;">当前提交: --</span>
-          </div>
-        </div>
-        <button id="nextSnapshot" class="timeline-btn" title="下一个时刻">▶</button>
-      </div>
-    </div>
-    <div class="card table-card">
-      <div id="stream-table-container">
-        <!-- 流式表格内容将由 JS 动态填充 -->
-      </div>
-    </div>
-    <div class="card chart-card">
-      <canvas id="scoreChart"></canvas>
-    </div>
+<div class="container py-4">
+  <h2 class="mb-3">流式榜单</h2>
+  <div class="mb-2">
+    <input type="text" id="searchInput" class="form-control" placeholder="搜索用户名...">
   </div>
+  <div class="mb-2 d-flex align-items-center">
+    <button id="prevSnapshot" class="btn btn-outline-primary me-2">◀</button>
+    <input type="range" id="timelineSlider" min="0" max="100" value="100" class="form-range flex-grow-1">
+    <button id="nextSnapshot" class="btn btn-outline-primary ms-2">▶</button>
+    <span id="timelineCurrent" class="ms-3">当前提交: --</span>
+  </div>
+  <div id="stream-table-container"></div>
+  <div style="margin-bottom: 1em;">
+  <button id="pause-btn" class="standing-btn" style="margin-right: 1em;">暂停获取</button>
+  <a href="/standing/data/{{ task_id }}" id="fixed-btn" class="standing-btn">跳转到固定榜单</a>
 </div>
-<script src="{{ url_for('static', filename='js/standing.js') }}"></script>
-<script src="{{ url_for('static', filename='js/standing-anim.js') }}"></script>
+</div>
 <script>
-// 记录上一次分数快照和排名快照
-let lastScoreSnapshot = {};
-let lastRankSnapshot = [];
+let timelineData = [], tableHeader = [], users = [], problems = [], problemMap = {}, lastScoreSnapshot = {}, lastRankSnapshot = [];
+window.submission_history = {};
 function getCurrentRankSnapshot() {
   return Array.from(document.querySelectorAll('#rank-table tbody tr')).map(row => row.querySelector('.username-cell').textContent);
 }
-// 包装表格渲染函数，添加分数和排名动画
-const origRenderTableBySnapshot = window.renderTableBySnapshot;
-window.renderTableBySnapshot = function(idx) {
-  origRenderTableBySnapshot(idx);
-  // 分数动画（只对变化的）
+function renderTableBySnapshot(idx) {
+  if (!timelineData.length || !users.length || !tableHeader.length) return;
+  const snapshot = timelineData[idx];
+  const userScores = {};
+  users.forEach(u => { userScores[u] = {}; problems.forEach(p => { userScores[u][p] = 0; }); });
+  for (let i = 0; i <= idx; ++i) {
+    const snap = timelineData[i];
+    if (userScores[snap.username] && userScores[snap.username][snap.problemId] !== undefined) {
+      userScores[snap.username][snap.problemId] = snap.score;
+    }
+  }
+  const userTotal = users.map(u => {
+    let total = 0;
+    problems.forEach(p => { total += userScores[u][p]; });
+    return { user: u, total, scores: problems.map(p => userScores[u][p]) };
+  });
+  userTotal.sort((a, b) => b.total - a.total);
+  let html = '<table id="rank-table" class="table table-hover"><thead><tr>';
+  html += '<th>排名</th><th>用户名</th>';
+  problems.forEach(p => {
+    html += `<th>${problemMap && problemMap[p] ? p+':'+problemMap[p] : p}</th>`;
+  });
+  html += '<th>总分</th></tr></thead><tbody>';
+  userTotal.forEach((row, i) => {
+    html += `<tr><td class="rank-cell">${i+1}</td><td class="username-cell">${row.user}</td>`;
+    row.scores.forEach((s, j) => {
+      let historyHtml = '';
+      if (window.submission_history && window.submission_history[row.user] && window.submission_history[row.user][problems[j]]) {
+        const historyArr = window.submission_history[row.user][problems[j]];
+        if (historyArr.length > 0) {
+          historyHtml = '<div class="submission-history">' + historyArr.map(item =>
+            `<div class=\"history-item\"><a href=\"http://oj.daimayuan.top/submission/${item[0]}\" class=\"submission-link\" target=\"_blank\">#${item[0]}</a><span class=\"score\">${item[1]}</span></div>`
+          ).join('') + '</div>';
+        }
+      }
+      html += `<td class=\"score-cell\"><span class=\"score-text\">${s}</span>${historyHtml}</td>`;
+    });
+    html += `<td class=\"score-cell\"><span class=\"score-text\">${row.total}</span></td></tr>`;
+  });
+  html += '</tbody></table>';
+  document.getElementById('stream-table-container').innerHTML = html;
+  // 分数颜色
+  if (typeof chroma !== 'undefined') {
+    const colorScale = chroma.scale(['#e74c3c', '#f39c12', '#27ae60']).domain([0, 50, 100]);
+    document.querySelectorAll('#rank-table tbody td.score-cell').forEach(cell => {
+      let scoreSpan = cell.querySelector('.score-text');
+      if (!scoreSpan) return;
+      const score = parseFloat(scoreSpan.textContent);
+      const isTotalScore = cell.cellIndex === cell.parentElement.cells.length - 1;
+      const maxScore = isTotalScore ? 300 : 100;
+      if (score < 0) {
+        scoreSpan.style.color = '#95a5a5';
+      } else {
+        let percent = Math.max(0, Math.min(1, score / maxScore));
+        scoreSpan.style.color = colorScale(percent * 100).hex();
+        scoreSpan.style.background = '';
+      }
+    });
+  }
+  // Tablesort
+  const table = document.getElementById('rank-table');
+  if (table && typeof Tablesort === 'function') {
+    try { new Tablesort(table); } catch(e){}
+  }
+}
+function updateTimelineBySlider(val) {
+  if (!timelineData.length) return;
+  const idx = Math.round((val / 100) * (timelineData.length - 1));
+  const data = timelineData[idx];
+  const cur = document.getElementById('timelineCurrent');
+  if (cur && data && data.submissionId !== undefined) {
+    cur.textContent = '当前提交: #' + data.submissionId;
+  } else if (cur) {
+    cur.textContent = '当前提交: --';
+  }
+  renderTableBySnapshot(idx);
   setTimeout(() => {
+    // 分数动画
     let curScoreSnapshot = {};
     document.querySelectorAll('#rank-table tbody tr').forEach(row => {
       const user = row.querySelector('.username-cell').textContent;
@@ -121,220 +175,82 @@ window.renderTableBySnapshot = function(idx) {
       lastRankSnapshot = getCurrentRankSnapshot();
     }
   }, 30);
-};
-// 修正表头和分数颜色
-function fixTableHeaderAndColor() {
-  // 修正表头（如有需要可自定义）
-  const table = document.getElementById('rank-table');
-  if (table) {
-    // 例如：将表头内容全部转为中文（如有需要可自定义映射）
-    const ths = table.querySelectorAll('thead th');
-    ths.forEach((th, idx) => {
-      // 这里可以自定义表头映射
-      if (th.textContent === '用户名') th.textContent = '用户名';
-      if (th.textContent.match(/^\d+$/)) th.textContent = '题目' + th.textContent;
-      if (th.textContent === '总分') th.textContent = '总分';
-    });
-  }
 }
-// 监听 SSE 数据渲染后修正
-eventSource.onmessage = function(e) {
-  if (typeof origEventSource === 'function') origEventSource.call(this, e);
-  setTimeout(fixTableHeaderAndColor, 100); // 等待表格渲染后修正
-};
-// 页面初次加载也修正一次
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', fixTableHeaderAndColor);
-} else {
-  fixTableHeaderAndColor();
-}
-</script>
-<script>
-let timelineData = [];
-let tableHeader = [];
-let users = [];
-let problems = [];
-let problemMap = {};
-
-function renderTableBySnapshot(idx) {
-  if (!timelineData.length || !users.length || !tableHeader.length) return;
-  // 1. 计算当前快照所有用户每题分数
-  const snapshot = timelineData[idx];
-  // 构建分数字典：user -> problem -> score
-  const userScores = {};
-  users.forEach(u => { userScores[u] = {}; problems.forEach(p => { userScores[u][p] = 0; }); });
-  // 累加到当前快照
-  for (let i = 0; i <= idx; ++i) {
-    const snap = timelineData[i];
-    if (userScores[snap.username] && userScores[snap.username][snap.problemId] !== undefined) {
-      userScores[snap.username][snap.problemId] = snap.score;
-    }
-  }
-  // 2. 计算总分并排序
-  const userTotal = users.map(u => {
-    let total = 0;
-    problems.forEach(p => { total += userScores[u][p]; });
-    return { user: u, total, scores: problems.map(p => userScores[u][p]) };
-  });
-  userTotal.sort((a, b) => b.total - a.total);
-  // 3. 渲染表格（修正表头和列顺序）
-  let html = '<table id="rank-table" class="table table-hover"><thead><tr>';
-  html += '<th>排名</th><th>用户名</th>';
-  problems.forEach(p => {
-    if (problemMap && problemMap[p]) {
-      html += `<th>${p}：${problemMap[p]}</th>`;
-    } else {
-      html += `<th>${p}</th>`;
-    }
-  });
-  html += '<th>总分</th></tr></thead><tbody>';
-  userTotal.forEach((row, i) => {
-    html += `<tr><td class="rank-cell">${i+1}</td><td class="username-cell">${row.user}</td>`;
-    row.scores.forEach((s, j) => {
-      // 拼接提交历史
-      let historyHtml = '';
-      if (window.submission_history && window.submission_history[row.user] && window.submission_history[row.user][problems[j]]) {
-        const historyArr = window.submission_history[row.user][problems[j]];
-        if (historyArr.length > 0) {
-          historyHtml = '<div class="submission-history">' + historyArr.map(item =>
-            `<div class=\"history-item\"><a href=\"http://oj.daimayuan.top/submission/${item[0]}\" class=\"submission-link\" target=\"_blank\">#${item[0]}</a><span class=\"score\">${item[1]}</span></div>`
-          ).join('') + '</div>';
-        }
-      }
-      html += `<td class=\"score-cell\"><span class=\"score-text\">${s}</span>${historyHtml}</td>`;
-    });
-    html += `<td class=\"score-cell\"><span class=\"score-text\">${row.total}</span></td></tr>`;
-  });
-  html += '</tbody></table>';
-  document.getElementById('stream-table-container').innerHTML = html;
-  colorScoreCellsForNewStanding();
-}
-
-function updateTimelineBySlider(val) {
-  if (!timelineData.length) return;
-  const idx = Math.round((val / 100) * (timelineData.length - 1));
-  const data = timelineData[idx];
-  // 动态显示当前提交编号
-  const cur = document.getElementById('timelineCurrent');
-  if (cur && data && data.submissionId !== undefined) {
-    cur.textContent = '当前提交: #' + data.submissionId;
-  } else if (cur) {
-    cur.textContent = '当前提交: --';
-  }
-  renderTableBySnapshot(idx);
-}
-
-// timeline 滑块和左右按钮事件绑定
-function bindTimelineEvents() {
-  const slider = document.getElementById('timelineSlider');
-  const prevBtn = document.getElementById('prevSnapshot');
-  const nextBtn = document.getElementById('nextSnapshot');
-  if (!slider || !timelineData.length) return;
-  let currentIdx = timelineData.length - 1;
-  slider.addEventListener('input', function() {
-    currentIdx = Math.round((this.value / 100) * (timelineData.length - 1));
-    updateTimelineBySlider(this.value);
-  });
-  prevBtn && prevBtn.addEventListener('click', function() {
-    if (currentIdx > 0) {
-      currentIdx--;
-      slider.value = (currentIdx / (timelineData.length - 1)) * 100;
-      updateTimelineBySlider(slider.value);
-    }
-  });
-  nextBtn && nextBtn.addEventListener('click', function() {
-    if (currentIdx < timelineData.length - 1) {
-      currentIdx++;
-      slider.value = (currentIdx / (timelineData.length - 1)) * 100;
-      updateTimelineBySlider(slider.value);
-    }
-  });
-}
-
-window.eventSource = new EventSource(`/standing/stream/{{ task_id }}`);
-window.eventSource.onmessage = function(e) {
-  const data = JSON.parse(e.data);
-  timelineData = data.timeline_data || [];
-  tableHeader = data.table_header || [];
-  users = data.users || [];
-  problems = data.problems || [];
-  problemMap = data.problem_map || {};
-  window.submission_history = data.submission_history || {};
-  if (data.error) {
-    document.getElementById('stream-table-container').innerHTML = `<div>${data.error}</div>`;
-    return;
-  }
-  // 每次收到数据都刷新表格并触发动画
-  if (timelineData.length) {
-    document.getElementById('timelineSlider').value = 100;
-    // 先渲染表格
-    updateTimelineBySlider(100);
-    // 触发动画：对所有分数单元格添加 score-change 动画类
-    setTimeout(() => {
-      document.querySelectorAll('#rank-table .score-cell .score-text').forEach(span => {
-        span.classList.remove('score-change');
-        // 强制重绘
-        void span.offsetWidth;
-        span.classList.add('score-change');
-      });
-      // 新增：对所有排名单元格触发排名动画
-      if (window.standingAnim && window.standingAnim.applyRankAnimation) {
-        const rows = Array.from(document.querySelectorAll('#rank-table tbody tr'));
-        const oldPositions = new Map();
-        rows.forEach((r, i) => oldPositions.set(r.querySelector('.username-cell').textContent, i));
-        // 以当前顺序为 oldPositions，下一次渲染后再触发动画
-        setTimeout(() => {
-          const newRows = Array.from(document.querySelectorAll('#rank-table tbody tr'));
-          window.standingAnim.applyRankAnimation(newRows, oldPositions, newRows);
-        }, 10);
-      }
-    }, 50);
-    bindTimelineEvents();
-  }
-};
-window.eventSource.onerror = function() {
-  window.eventSource.close();
-};
-// 独立提取分数颜色渲染函数，供本页面表格渲染后调用，不影响 standing.html
-function colorScoreCellsForNewStanding() {
-  if (typeof chroma === 'undefined') return;
-  const colorScale = chroma.scale(['#e74c3c', '#f39c12', '#27ae60']).domain([0, 50, 100]);
-  document.querySelectorAll('#rank-table tbody td.score-cell').forEach(cell => {
-    let scoreSpan = cell.querySelector('.score-text');
-    if (!scoreSpan) return;
-    const score = parseFloat(scoreSpan.textContent);
-    const isTotalScore = cell.cellIndex === cell.parentElement.cells.length - 1;
-    const maxScore = isTotalScore ? 300 : 100;
-    if (score < 0) {
-      scoreSpan.style.color = '#95a5a5';
-    } else {
-      let percent = Math.max(0, Math.min(1, score / maxScore));
-      scoreSpan.style.color = colorScale(percent * 100).hex();
-      scoreSpan.style.background = '';
-      scoreSpan.style.backgroundClip = '';
-      scoreSpan.style.webkitBackgroundClip = '';
-    }
-  });
-}
-// 在 renderTableBySnapshot 渲染后调用
-renderTableBySnapshot = function(idx) {
-  origRenderTableBySnapshot(idx);
-  colorScoreCellsForNewStanding();
-};
 document.getElementById('timelineSlider').addEventListener('input', function() {
   updateTimelineBySlider(this.value);
 });
+document.getElementById('searchInput').addEventListener('input', function(e) {
+  const searchTerm = e.target.value.toLowerCase().trim();
+  const rows = document.querySelectorAll('#rank-table tbody tr');
+  rows.forEach(row => {
+    const username = row.cells[1].textContent.toLowerCase();
+    row.style.display = username.includes(searchTerm) ? '' : 'none';
+  });
+});
+document.getElementById('prevSnapshot').addEventListener('click', function() {
+  const slider = document.getElementById('timelineSlider');
+  let idx = Math.round((slider.value / 100) * (timelineData.length - 1));
+  if (idx > 0) {
+    idx--;
+    slider.value = (idx / (timelineData.length - 1)) * 100;
+    updateTimelineBySlider(slider.value);
+  }
+});
+document.getElementById('nextSnapshot').addEventListener('click', function() {
+  const slider = document.getElementById('timelineSlider');
+  let idx = Math.round((slider.value / 100) * (timelineData.length - 1));
+  if (idx < timelineData.length - 1) {
+    idx++;
+    slider.value = (idx / (timelineData.length - 1)) * 100;
+    updateTimelineBySlider(slider.value);
+  }
+});
+let paused = false;
+let eventSource = null;
+const pauseBtn = document.getElementById('pause-btn');
+
+function startSSE() {
+  if (eventSource) eventSource.close();
+  eventSource = new EventSource(`/standing/stream/{{ task_id }}`);
+  eventSource.onmessage = function(e) {
+    if (paused) return;
+    let data;
+    try { data = JSON.parse(e.data); } catch (err) {
+      document.getElementById('stream-table-container').innerHTML = `<div>数据解析失败: ${err}</div>`;
+      return;
+    }
+    if (data.error) {
+      document.getElementById('stream-table-container').innerHTML = `<div>${data.error}</div>`;
+      return;
+    }
+    timelineData = data.timeline_data || [];
+    tableHeader = data.table_header || [];
+    users = data.users || [];
+    problems = data.problems || [];
+    problemMap = data.problem_map || {};
+    window.submission_history = data.submission_history || {};
+    if (!timelineData.length || !users.length || !problems.length) {
+      document.getElementById('stream-table-container').innerHTML = `<div>暂无榜单数据</div>`;
+      return;
+    }
+    document.getElementById('timelineSlider').value = 100;
+    updateTimelineBySlider(100);
+  };
+}
+
+pauseBtn.onclick = function() {
+  paused = !paused;
+  pauseBtn.textContent = paused ? '恢复获取' : '暂停获取';
+  if (paused && eventSource) {
+    eventSource.close();
+    eventSource = null;
+  } else if (!paused && !eventSource) {
+    startSSE();
+  }
+};
+
+// 页面加载时自动启动 SSE
+startSSE();
 </script>
-<style>
-@keyframes scoreChange {
-  0% { background-color: transparent; }
-  10%   { transform: scale(1.2); background-color: transparent; }
-  100% { background-color: transparent; }
-}
-.score-change {
-  display: inline-block;
-  animation: scoreChange 0.45s ease-out;
-}
-</style>
 </body>
 </html>

--- a/app/templates/new_standing.html
+++ b/app/templates/new_standing.html
@@ -11,47 +11,33 @@
   <script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chroma-js@2.4.2/chroma.min.js"></script>
   <script src="{{ url_for('static', filename='js/standing-anim.js') }}"></script>
-  <style>
-    @keyframes scoreChange { 0% { background-color: transparent; } 10% { transform: scale(1.2); background-color: transparent; } 100% { background-color: transparent; } }
-    .score-change { display: inline-block; animation: scoreChange 0.45s ease-out; }
-    /* 按钮样式与 standing.css 风格一致 */
-.standing-btn, #pause-btn {
-  display: inline-block;
-  padding: 6px 18px;
-  margin: 0 4px;
-  background: #fff;
-  border: 1px solid #bbb;
-  border-radius: 4px;
-  color: #333;
-  font-size: 15px;
-  cursor: pointer;
-  transition: background 0.2s, color 0.2s;
-  text-decoration: none;
-}
-.standing-btn:hover, #pause-btn:hover {
-  background: #f0f0f0;
-  color: #1976d2;
-  border-color: #1976d2;
-}
-  </style>
 </head>
 <body>
-<div class="container py-4">
-  <h2 class="mb-3">流式榜单</h2>
-  <div class="mb-2">
-    <input type="text" id="searchInput" class="form-control" placeholder="搜索用户名...">
+<div class="main-container">
+  <div class="content-wrapper">
+    <div class="header">
+      <h1>流式榜单</h1>
+    </div>
+    <div class="card">
+      <div class="mb-2">
+        <input type="text" id="searchInput" class="form-control" placeholder="搜索用户名...">
+      </div>
+      <div class="mb-2 d-flex align-items-center">
+        <button id="prevSnapshot" class="btn btn-outline-primary me-2">◀</button>
+        <input type="range" id="timelineSlider" min="0" max="100" value="100" class="form-range flex-grow-1">
+        <button id="nextSnapshot" class="btn btn-outline-primary ms-2">▶</button>
+        <span id="timelineCurrent" class="ms-3">当前提交: --</span>
+      </div>
+      <div id="stream-table-container"></div>
+      <div class="d-flex justify-content-center gap-3 mb-3">
+        <button id="pause-btn" class="standing-btn">暂停获取</button>
+        <a href="/standing/data/{{ task_id }}" id="fixed-btn" class="standing-btn">跳转到固定榜单</a>
+      </div>
+    </div>
+    <div class="footer">
+      <p>数据流式刷新 | <a href="/tasklist" style="color: #007BFF; text-decoration: none;">查看其他任务</a></p>
+    </div>
   </div>
-  <div class="mb-2 d-flex align-items-center">
-    <button id="prevSnapshot" class="btn btn-outline-primary me-2">◀</button>
-    <input type="range" id="timelineSlider" min="0" max="100" value="100" class="form-range flex-grow-1">
-    <button id="nextSnapshot" class="btn btn-outline-primary ms-2">▶</button>
-    <span id="timelineCurrent" class="ms-3">当前提交: --</span>
-  </div>
-  <div id="stream-table-container"></div>
-  <div style="margin-bottom: 1em;">
-  <button id="pause-btn" class="standing-btn" style="margin-right: 1em;">暂停获取</button>
-  <a href="/standing/data/{{ task_id }}" id="fixed-btn" class="standing-btn">跳转到固定榜单</a>
-</div>
 </div>
 <script>
 let timelineData = [], tableHeader = [], users = [], problems = [], problemMap = {}, lastScoreSnapshot = {}, lastRankSnapshot = [];

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -68,8 +68,8 @@
                     <th>比赛编号</th>
                     <th>状态</th>
                     <th>扫描范围</th>
-                    <th>进度</th>
-                    <th>剩余存在时间</th>
+                    <th class="task-progress-cell">进度</th>
+                    <th class="task-remaining-cell">剩余存在时间</th>
                     <th>操作</th>
                 </tr>
             </thead>

--- a/config.yaml
+++ b/config.yaml
@@ -42,3 +42,4 @@ task:
   savetime: 1200  # 任务保存时间（秒）
   max_runtime: 7200  # 任务最大运行时间（秒）
   cleanup_interval: 60  # 清理检查间隔（秒）
+  push_interval: 5  # 数据推送间隔（秒，可配置）


### PR DESCRIPTION
实现方式是：每5s执行所有榜单任务。判断404，操作状态进行下去。操作入口在下方。
![image](https://github.com/user-attachments/assets/5be7f3af-e5fc-4fe3-8e8c-cf81a519111d)
（是不是该改一下按钮来着）
![image](https://github.com/user-attachments/assets/0fa78068-1a1b-4d34-bdba-56c7e0051b47)
当然自动跳转。顺序是不是得改一下。
![image](https://github.com/user-attachments/assets/517883fe-2946-4e9f-8323-5b7ab5e0c38d)
左边展示类型。
![image](https://github.com/user-attachments/assets/a63c16a1-3bbe-4312-a37c-9e1eeea26876)
这里暂停获取是仅客户端的。跳转到固定榜单是用现有数据跳到原来的standing.html。
![image](https://github.com/user-attachments/assets/a9aa651e-8926-40d7-9a94-64d629228a9b)
带自动动画。获取到新的数据且没有暂停则自动更新到最新。

应该是最后一次了。
